### PR TITLE
Kalkun Whitelist plugin

### DIFF
--- a/application/plugins/whitelist_number/controllers/whitelist_number.php
+++ b/application/plugins/whitelist_number/controllers/whitelist_number.php
@@ -1,0 +1,64 @@
+<?php
+/**
+ * Kalkun
+ * An open source web based SMS Management
+ *
+ * @package		Kalkun
+ * @author		Kalkun Dev Team
+ * @license		http://kalkun.sourceforge.net/license.php
+ * @link		http://kalkun.sourceforge.net
+ */
+
+// ------------------------------------------------------------------------
+
+/**
+ * Blacklist_number Class
+ *
+ * @package		Kalkun
+ * @subpackage	Plugin
+ * @category	Controllers
+ */
+include_once(APPPATH.'plugins/Plugin_Controller.php');
+
+class Whitelist_number extends Plugin_Controller {
+	
+	function Whitelist_number()
+	{
+		parent::Plugin_Controller();		
+		$this->load->model('Kalkun_model');
+		$this->load->model('whitelist_number_model', 'plugin_model');
+	}
+	
+	function index()
+	{
+		if($_POST) 
+		{	
+			if($this->input->post('editid_whitelist_number')) $this->plugin_model->update();
+			else $this->plugin_model->add();
+			redirect('plugin/whitelist_number');
+		}
+
+		$this->load->library('pagination');
+		$config['base_url'] = site_url('plugin/whitelist_number');
+		$config['total_rows'] = $this->plugin_model->get('count');
+		$config['per_page'] = $this->Kalkun_model->get_setting()->row('paging');
+		$config['cur_tag_open'] = '<span id="current">';
+		$config['cur_tag_close'] = '</span>';		
+		$config['uri_segment'] = 3;
+		$this->pagination->initialize($config);
+				
+		$data['main'] = 'index';
+		$data['blacklist'] = $this->plugin_model->get('paginate', $config['per_page'], $this->uri->segment(3,0));
+		$data['number'] = $this->uri->segment(3,0)+1;
+		$this->load->view('main/layout', $data);
+	}
+	
+	function delete($id)
+	{
+		$this->plugin_model->delete($id);
+		redirect('plugin/whitelist_number');
+	}
+}
+	
+/* End of file whitelist_number.php */
+/* Location: ./application/plugins/whitelist_number/controllers/whitelist_number.php */

--- a/application/plugins/whitelist_number/media/mysql_whitelist_number.sql
+++ b/application/plugins/whitelist_number/media/mysql_whitelist_number.sql
@@ -1,0 +1,11 @@
+-- --------------------------------------------------------
+
+--
+-- Table structure for table `plugin_whitelist_number`
+--
+
+CREATE TABLE IF NOT EXISTS `plugin_whitelist_number` (
+  `id_whitelist` int(5) NOT NULL AUTO_INCREMENT,
+  `match` varchar(200) NOT NULL,
+  PRIMARY KEY (`id_whitelist`)
+) ENGINE=MyISAM  DEFAULT CHARSET=latin1;

--- a/application/plugins/whitelist_number/media/pgsql_whitelist_number.sql
+++ b/application/plugins/whitelist_number/media/pgsql_whitelist_number.sql
@@ -1,0 +1,4 @@
+CREATE TABLE "plugin_whitelist_number" (
+	"id_whitelist" serial PRIMARY KEY, 
+	"match" varchar(200) NOT NULL
+);

--- a/application/plugins/whitelist_number/media/sqlite_whitelist_number.sql
+++ b/application/plugins/whitelist_number/media/sqlite_whitelist_number.sql
@@ -1,0 +1,4 @@
+CREATE TABLE "plugin_whitelist_number" (
+	"id_whitelist" INTEGER PRIMARY KEY AUTOINCREMENT, 
+	"match" VARCHAR(200) NOT NULL
+);

--- a/application/plugins/whitelist_number/models/whitelist_number_model.php
+++ b/application/plugins/whitelist_number/models/whitelist_number_model.php
@@ -1,0 +1,73 @@
+<?php
+/**
+ * Kalkun
+ * An open source web based SMS Management
+ *
+ * @package		Kalkun
+ * @author		Kalkun Dev Team
+ * @license		http://kalkun.sourceforge.net/license.php
+ * @link		http://kalkun.sourceforge.net
+ */
+
+// ------------------------------------------------------------------------
+
+/**
+ * Whitelist_number_model Class
+ *
+ * Handle all plugin database activity 
+ *
+ * @package		Kalkun
+ * @subpackage	Plugin
+ * @category	Models
+ */
+class Whitelist_number_model extends Model {
+	
+	function Whitelist_number_model()
+	{
+		parent::Model();
+	}	
+	
+	function get($option=NULL, $limit=NULL, $offset=NULL)
+	{
+		switch($option)
+		{
+			case 'all':
+				return $this->db->get('plugin_whitelist_number');
+			break;
+			
+			case 'paginate':
+				return $this->db->get('plugin_whitelist_number', $limit, $offset);		
+			break;
+			
+			case 'count':
+				$this->db->select('count(*) as count');
+				return $this->db->get('plugin_whitelist_number')->row('count');
+			break;
+		}
+	}
+	
+	function add()
+	{
+		$data = array (
+				'match' => trim($this->input->post('match',TRUE)),
+					);
+		$this->db->insert('plugin_whitelist_number',$data);			
+	}
+
+	function update()
+	{
+		$data = array (
+				'match' => trim($this->input->post('editmatch',TRUE)),
+					);
+		$this->db->where('id_whitelist_number', $this->input->post('editid_whitelist_number',TRUE));			
+		$this->db->update('plugin_whitelist_number',$data);
+	}	
+	
+	function delete($id)
+	{
+		$this->db->delete('plugin_whitelist_number', array('id_whitelist_number' => $id)); 
+	}
+}
+
+/* End of file whitelist_number_model.php */
+/* Location: ./application/plugins/whitelist_number/models/whitelist_number_model.php */

--- a/application/plugins/whitelist_number/views/index.php
+++ b/application/plugins/whitelist_number/views/index.php
@@ -1,0 +1,68 @@
+<?php $this->load->view('js_whitelist_number');?>
+
+<!-- Add Whitelist dialog -->	
+<div id="whitelist-dialog" title="Add Whitelist Number" class="dialog">
+	<p id="validateTips">All form fields are required.</p>
+	<?php echo form_open('plugin/whitelist_number', array('class' => 'addwhitelistnumberform')); ?>
+	<fieldset>
+		<label for="phone_number">Match</label>
+		<input type="text" name="match" id="phone_number" class="text ui-widget-content ui-corner-all" />
+	</fieldset>
+	<?php echo form_close(); ?>
+</div>
+
+
+<!-- Edit Whitelist dialog -->
+<div id="editwhitelist-dialog" title="Edit Whitelist Number"  class="dialog">
+	<p id="validateTips">All form fields are required.</p>
+	<?php echo form_open('plugin/whitelist_number', array('class' => 'editwhitelistnumberform')); ?>
+	<fieldset>
+		<input type="hidden" name="editid_whitelist_number" id="editid_whitelist_number" />
+		<label for="editphone_number">Match</label>
+		<input type="text" name="editmatch" id="editphone_number" class="text ui-widget-content ui-corner-all" />
+	</fieldset>
+	<?php echo form_close(); ?>
+	</form>
+</div>
+
+<div id="space_area">
+<h3 style="float: left">Match</h3> 
+<div style="float: right">
+<a href="#" id="addwhitelistbutton" class="nicebutton">&#43; Add match rule</a>
+</div>
+
+	<table class="nice-table" cellpadding="0" cellspacing="0">
+		<tr>
+			<th class="nice-table-left">No.</th>
+			<th>Match</th>
+			<th class="nice-table-right" colspan="2">Control</th>
+		</tr>
+	    
+		<?php 
+		if($whitelist->num_rows()==0)
+		{
+			echo "<tr><td colspan=\"5\" style=\"border-left: 1px solid #000; border-right: 1px solid #000;\">No whitelist number found.</td></tr>";
+		}
+		else
+		{
+			foreach($whitelist->result() as $tmp):
+			?>
+			<tr id="<?php echo $tmp->id_whitelist_number;?>">
+				<td class="nice-table-left"><?php echo $number;?></td>
+				<td class="phone_number"><?php echo $tmp->phone_number;?></td>
+				<td><a href="#" class="edit"><img class="ui-icon ui-icon-pencil" title="Edit" /></a></td>
+				<td class="nice-table-right"><a href="<?php echo site_url();?>/plugin/whitelist_number/delete/<?php echo $tmp->id_whitelist_number;?>"><img class="ui-icon ui-icon-close" title="Delete" /></a></td>
+			</tr>
+			
+			<?php 
+			$number++;
+			endforeach;
+		} 
+		?>
+		<tr>
+			<th colspan="5" class="nice-table-footer"><div id="simplepaging"><?php echo $this->pagination->create_links();?></div></th>	
+		</tr>
+		
+	</table>
+	<br />
+</div>

--- a/application/plugins/whitelist_number/views/js_whitelist_number.php
+++ b/application/plugins/whitelist_number/views/js_whitelist_number.php
@@ -1,0 +1,59 @@
+<script type="text/javascript">
+$(document).ready(function() {
+    
+    // background
+    $("tr:odd").addClass('hover_color');
+
+	// Add whitelist dialog
+	$("#whitelist-dialog").dialog({
+		bgiframe: true,
+		autoOpen: false,
+		height: 250,
+		modal: true,
+		buttons: {
+			'Save': function() {
+				$("form.addwhitelistnumberform").submit();
+			},
+			Cancel: function() {
+				$(this).dialog('close');
+			}
+		}
+	});
+	
+	// Add whitelist button	
+	$('#addwhitelistbutton').click(function() {
+		$('#whitelist-dialog').dialog('open');
+	});
+
+
+	
+	// Edit whitelist dialog
+	$("#editwhitelist-dialog").dialog({
+		bgiframe: true,
+		autoOpen: false,
+		height: 250,
+		modal: true,
+		buttons: {
+			'Save Changes': function() {
+				$("form.editwhitelistnumberform").submit();
+			},
+			Cancel: function() {
+				$(this).dialog('close');
+			}
+		}
+	});
+
+	
+	// Edit whitelist - get data
+	$('a.edit').click(function() {
+		var editid_whitelist_number = $(this).parents("tr:first").attr("id");
+		$("#editid_whitelist_number").val(editid_whitelist_number);		
+		var editphone_number = $(this).parents("tr:first").children("td.phone_number").text();
+		$("#editphone_number").val(editphone_number);
+		var editreason = $(this).parents("tr:first").children("td.reason").text();
+		$("#editreason").val(editreason);
+		$('#editwhitelist-dialog').dialog('open');
+	});		
+
+});    
+</script>

--- a/application/plugins/whitelist_number/whitelist_number.php
+++ b/application/plugins/whitelist_number/whitelist_number.php
@@ -1,0 +1,82 @@
+<?php
+/**
+* Plugin Name: Whitelist Number
+* Version: 1.0
+* Description: Autoremove outgoing SMS not in whitelist
+* Author: Максим Морэ
+* Author URI: https://bitbucket.org/maxsamael
+*/
+
+// Add hook for outgoing message
+add_action("message.outgoing", "whitelist_number_outgoing", 1);
+
+function whitelist_number_activate()
+{
+    return true;
+}
+
+/**
+* Function called when plugin deactivated
+* Utility function must be prefixed with the plugin name
+* followed by an underscore.
+* 
+* Format: pluginname_deactivate
+* 
+*/
+function whitelist_number_deactivate()
+{
+    return true;
+}
+
+/**
+* Function called when plugin first installed into the database
+* Utility function must be prefixed with the plugin name
+* followed by an underscore.
+* 
+* Format: pluginname_install
+* 
+*/
+function whitelist_number_install()
+{
+	$CI =& get_instance();
+	$CI->load->helper('kalkun');
+	// check if table already exist
+	if (!$CI->db->table_exists('plugin_whitelist_number'))
+	{
+		$db_driver = $CI->db->platform();
+		$db_prop = get_database_property($db_driver);
+		execute_sql(APPPATH."plugins/whitelist_number/media/".$db_prop['file']."_whitelist_number.sql");
+	}
+  return true;
+}
+
+function whitelist_number_outgoing($numbers = array())
+{
+    $CI =& get_instance();
+    $CI->load->model('whitelist_number/whitelist_number_model', 'plugin_model');
+    $heaven = array();
+    
+    // Get whitelist number
+    $lists = $CI->plugin_model->get('all')->result_array();
+    foreach($lists as $tmp)
+    {
+    	$heaven[] = $tmp['match'];
+    }
+    
+    // Delete number if it's on whitelist number
+    foreach($numbers as $key => $number)
+    {
+	    foreach($heaven as $match) {
+        if(preg_match($match,$number))
+  	    {
+  	    	continue;
+  	    } else {
+          unset($numbers[$key]);
+        }
+      }
+	}
+	return $numbers;
+}
+
+/* End of file whitelist_number.php */
+/* Location: ./application/plugins/whitelist_number/whitelist_number.php */


### PR DESCRIPTION
Kalkun whitelist:
Before sending check the number by preg_match expressions stored in db.
Admins can filtrate the white numbers by expression.
You can remake the code. Or comment anything there.
Is it based on black list.
I think this missing and it can be usefull for many users.
