### PR TITLE
[plugin/server_alert]: fix the db create script for pg

### DIFF
--- a/application/plugins/server_alert/media/pgsql_server_alert.sql
+++ b/application/plugins/server_alert/media/pgsql_server_alert.sql
@@ -1,6 +1,6 @@
 CREATE TABLE "plugin_server_alert" (
-	"id_server_alert" serial INTEGER PRIMARY KEY, 
-	"alert_name" varchar(100) NOT NULL, 
+	"id_server_alert" serial PRIMARY KEY,
+	"alert_name" varchar(100) NOT NULL,
 	"ip_address" varchar(20) NOT NULL,
 	"port_number" integer NOT NULL,
 	"timeout" integer NOT NULL DEFAULT '30',


### PR DESCRIPTION
The primary key has to be either serial or integer, not both.
Fixing to use serial.

Also fixes white spaces.
