### PR TITLE
Create tables 'pbk' & 'pbk_groups' for postgreSQL schema

### DIFF
--- a/media/db/pgsql_kalkun.sql
+++ b/media/db/pgsql_kalkun.sql
@@ -73,6 +73,23 @@ ALTER TABLE "inbox" ADD COLUMN "readed" text NOT NULL DEFAULT 'false';
 
 ALTER TABLE "sentitems" ADD COLUMN "id_folder" integer NOT NULL DEFAULT 3;
 
+-- --------------------------------------------------------
+-- pbk & pbk_groups tables have been removed from gammu-smsd Databse
+-- in schema version 16 (corresponding to gammu 1.37.90)
+-- This will create them as they used to be created by gammu.
+
+CREATE TABLE pbk (
+  "ID" serial PRIMARY KEY,
+  "GroupID" integer NOT NULL DEFAULT '-1',
+  "Name" text NOT NULL,
+  "Number" text NOT NULL
+);
+
+CREATE TABLE pbk_groups (
+  "Name" text NOT NULL,
+  "ID" serial PRIMARY KEY
+);
+
 ALTER TABLE "pbk" ADD COLUMN "id_user" integer NULL;
 ALTER TABLE "pbk" ADD COLUMN "is_public" text NOT NULL DEFAULT 'false';
 


### PR DESCRIPTION
pbk & pbk_groups tables have been removed from gammu-smsd Databse
in schema version 16 (corresponding to gammu 1.37.90)
This will create them as they used to be created by gammu.