### PR TITLE
routes: fix routes to avoid plugin 404 error

### DIFF
--- a/application/config/routes.php
+++ b/application/config/routes.php
@@ -48,7 +48,7 @@ $route['logout'] = "login/logout";
 //$route['phonebook'] = "kalkun/phonebook/0";
 //$route['phonebook/(:num)'] = "kalkun/phonebook/$1";
 
-$route['plugin/(:any)'] = "$1";
+$route['plugin/(.+)'] = "$1";
 $route['settings/(:any)'] = "kalkun/settings/$1";
 $route['about'] = "kalkun/about";
 


### PR DESCRIPTION
Since migration to CodeIgniter 3, some plugins still have 404-Error

Ref: https://codeigniter.com/user_guide/installation/upgrade_300.html?highlight=input#routes-containing-any
"In CodeIgniter 3, the :any wildcard will now represent [^/]+, so that it will not match a forward slash."

For example when using the Rest Api plugin, there was still a 404 Error when accessing this because of the reason stated above
http://kalkun-url/index.php/plugin/rest_api/send_sms?phoneNumber=123456&message=testing