### PR TITLE
Add new "compose_process_api" as a wrapper for "compose_process"

### DIFF
--- a/application/controllers/Form_result.php
+++ b/application/controllers/Form_result.php
@@ -1,0 +1,9 @@
+<?php
+class Form_result extends CI_Controller
+{
+	public function index($ret)
+	{
+		$this->load->view('main/form_result', array('result' => base64_decode(urldecode($ret))));
+	}
+}
+?>

--- a/application/controllers/Form_result.php
+++ b/application/controllers/Form_result.php
@@ -1,9 +1,0 @@
-<?php
-class Form_result extends CI_Controller
-{
-	public function index($ret)
-	{
-		$this->load->view('main/form_result', array('result' => base64_decode(urldecode($ret))));
-	}
-}
-?>

--- a/application/controllers/Info_message.php
+++ b/application/controllers/Info_message.php
@@ -1,0 +1,9 @@
+<?php
+class Info_message extends CI_Controller
+{
+	public function index($ret)
+	{
+		$this->load->view('main/info_message', array('result' => base64_decode(urldecode($ret))));
+	}
+}
+?>

--- a/application/controllers/Messages.php
+++ b/application/controllers/Messages.php
@@ -155,13 +155,17 @@ class Messages extends MY_Controller {
 					// Some browsers like firefox don't honor the history.go() well in case of an onload event
 					// Hence this message with a link pointing to the history on which the user can click. ?>
 					<body onload="goBackToForm()">
-						<p>Login successful. But <?php echo strtoupper($this->session->flashdata('bef_login_method'));?> data lost during login process.<br> Please <a href="<?php echo $this->session->flashdata('bef_login_HTTP_REFERER')?>" onclick="goBackToForm()">go back to your form</a> and submit again.</p>
+						<p><?php
+							printf(lang('kalkun_msg_login_success_data_lost'), strtoupper($this->session->flashdata('bef_login_method')));
+							echo ' <br> ';
+							printf(lang('kalkun_msg_go_back_and_submit'), $this->session->flashdata('bef_login_HTTP_REFERER'));
+							?>
 					</body>
 				<?php } else {
 					// Here the user logged in and we could keeep the content of the POST.
 					// So resubmit the POSTed data directly to this page  ?>
 					<body onload="submitForm()">
-						<p>Login successful. Resubmitting Form.</p>
+						<p><?php echo lang('kalkun_msg_login_success_resubmit');?></p>
 						<form name="redirectpost" method="post" action="<?php echo current_url(); ?>">
 						<?php
 							if ( !is_null($this->session->flashdata('bef_login_post_data')) ) {
@@ -359,7 +363,7 @@ class Messages extends MY_Controller {
         if($this->config->item('disable_outgoing'))
         {
         	unset($dest);
-            $return_msg = "<div class=\"notif\">Outgoing SMS disabled</div>";
+            $return_msg = '<div class="notif">'.lang('kalkun_msg_outgoing_disabled').'</div>';
         }			
 			
   	    // if ndnc filtering enabled
@@ -374,7 +378,7 @@ class Messages extends MY_Controller {
                         if(DNDcheck($dest[$i]))
                         {
                             unset($dest[$i]);
-                            $return_msg = "<font color='red'>A number was found in DND Resitry. SMS sending was skipped for it.</font><br>" ;
+                            $return_msg = '<font color="red">'.lang('kalkun_msg_number_in_DND').'</font><br>' ;
                         }
                     }
                 }
@@ -382,7 +386,7 @@ class Messages extends MY_Controller {
                         if(DNDcheck($dest))
                         {
                             unset($dest);
-                            $return_msg = "<font color='red'>A number was found in DND Resitry. SMS sending was skipped for it.</font><br>" ;
+                            $return_msg = '<font color="red">'.lang('kalkun_msg_number_in_DND').'</font><br>' ;
                         }
                 }
             }
@@ -412,7 +416,7 @@ class Messages extends MY_Controller {
 			{
 				$msg_id = $this->Message_model->copy_message($this->input->post('msg_id'));
 				$this->Message_model->update_owner($msg_id, $id);
-	          	$return_msg = "<div class=\"notif\">Message successfully delivered to user inbox</div>";
+				$return_msg = '<div class="notif">'.lang('kalkun_msg_delivered_to_user_inbox').'</div>';
 			}
 		}
 		
@@ -458,16 +462,16 @@ class Messages extends MY_Controller {
 				$data['message'] = $backup['message'];
 				$n++;
 			}
-			$return_msg = "<div class=\"notif\">Your message has been moved to outbox and is ready for delivery.</div>";
+			$return_msg = '<div class="notif">'.lang('kalkun_msg_moved_to_outbox').'</div>';
 		}
         if(!isset($return_msg))
-             $return_msg = "<div class=\"notif\"><font color='red'>No number found. SMS not sent.</font></div>" ;
+             $return_msg = '<div class="notif"><font color="red">'.lang('kalkun_msg_no_numberfound').'</font></div>' ;
 
 		// Display sending status
 		echo $return_msg;
 
 		if ($this->input->post('redirect_to_form_result') == "1")
-			redirect('form_result/index/'.urlencode(base64_encode($return_msg)));
+			redirect('info_message/index/'.urlencode(base64_encode($return_msg)));
 	}
 
 	// --------------------------------------------------------------------
@@ -1013,7 +1017,7 @@ class Messages extends MY_Controller {
 
         if($param['option'] == 'permanent' AND $this->config->item('only_admin_can_permanently_delete') AND $this->session->userdata('level') != 'admin')
         {
-            echo 'Only administrator can permanently delete message';
+            echo lang('kalkun_msg_only_admin_can_permanently_delete');
             exit;
         }
 				

--- a/application/language/brazilian_portuguese/kalkun_lang.php
+++ b/application/language/brazilian_portuguese/kalkun_lang.php
@@ -194,6 +194,17 @@ $lang['kalkun_compose_import_file'] = "Importar de arquivo";
 $lang['kalkun_compose_counter_character'] = "caracteres";
 $lang['kalkun_compose_counter_message'] = "mensagem";
 
+// Messages controller
+$lang['kalkun_msg_login_success_data_lost'] = "Login successful. But %s data lost during login process.";
+$lang['kalkun_msg_go_back_and_submit'] = 'Please <a href="%s" onclick="goBackToForm()">go back to your form</a> and submit again.';
+$lang['kalkun_msg_login_success_resubmit'] = "Login successful. Resubmitting Form.";
+$lang['kalkun_msg_outgoing_disabled'] = "Outgoing SMS disabled";
+$lang['kalkun_msg_number_in_DND'] = "A number was found in DND Resitry. SMS sending was skipped for it.";
+$lang['kalkun_msg_delivered_to_user_inbox'] = "Message successfully delivered to user inbox";
+$lang['kalkun_msg_moved_to_outbox'] = "Your message has been moved to outbox and is ready for delivery";
+$lang['kalkun_msg_no_numberfound'] = "No number found. SMS not sent";
+$lang['kalkun_msg_only_admin_can_permanently_delete'] = "Only administrators can permanently delete messages";
+
 // Setting
 $lang['kalkun_setting_passwd_current'] = "Senha atual";
 $lang['kalkun_setting_passwd_forgot'] = "Esqueceu sua senha?";

--- a/application/language/czech/kalkun_lang.php
+++ b/application/language/czech/kalkun_lang.php
@@ -193,6 +193,17 @@ $lang['kalkun_compose_import_file'] = "Import from file";
 $lang['kalkun_compose_counter_character'] = "characters";
 $lang['kalkun_compose_counter_message'] = "message";
 
+// Messages controller
+$lang['kalkun_msg_login_success_data_lost'] = "Login successful. But %s data lost during login process.";
+$lang['kalkun_msg_go_back_and_submit'] = 'Please <a href="%s" onclick="goBackToForm()">go back to your form</a> and submit again.';
+$lang['kalkun_msg_login_success_resubmit'] = "Login successful. Resubmitting Form.";
+$lang['kalkun_msg_outgoing_disabled'] = "Outgoing SMS disabled";
+$lang['kalkun_msg_number_in_DND'] = "A number was found in DND Resitry. SMS sending was skipped for it.";
+$lang['kalkun_msg_delivered_to_user_inbox'] = "Message successfully delivered to user inbox";
+$lang['kalkun_msg_moved_to_outbox'] = "Your message has been moved to outbox and is ready for delivery";
+$lang['kalkun_msg_no_numberfound'] = "No number found. SMS not sent";
+$lang['kalkun_msg_only_admin_can_permanently_delete'] = "Only administrators can permanently delete messages";
+
 // Setting
 $lang['kalkun_setting_passwd_current'] = "Current Password";
 $lang['kalkun_setting_passwd_forgot'] = "Forgot your password?";

--- a/application/language/danish/kalkun_lang.php
+++ b/application/language/danish/kalkun_lang.php
@@ -193,6 +193,17 @@ $lang['kalkun_compose_import_file'] = "Importer fra fil";
 $lang['kalkun_compose_counter_character'] = "tegn";
 $lang['kalkun_compose_counter_message'] = "besked";
 
+// Messages controller
+$lang['kalkun_msg_login_success_data_lost'] = "Login successful. But %s data lost during login process.";
+$lang['kalkun_msg_go_back_and_submit'] = 'Please <a href="%s" onclick="goBackToForm()">go back to your form</a> and submit again.';
+$lang['kalkun_msg_login_success_resubmit'] = "Login successful. Resubmitting Form.";
+$lang['kalkun_msg_outgoing_disabled'] = "Outgoing SMS disabled";
+$lang['kalkun_msg_number_in_DND'] = "A number was found in DND Resitry. SMS sending was skipped for it.";
+$lang['kalkun_msg_delivered_to_user_inbox'] = "Message successfully delivered to user inbox";
+$lang['kalkun_msg_moved_to_outbox'] = "Your message has been moved to outbox and is ready for delivery";
+$lang['kalkun_msg_no_numberfound'] = "No number found. SMS not sent";
+$lang['kalkun_msg_only_admin_can_permanently_delete'] = "Only administrators can permanently delete messages";
+
 // Setting
 $lang['kalkun_setting_passwd_current'] = "Nuværende kodeord";
 $lang['kalkun_setting_passwd_forgot'] = "Glemt dit kodeord?";

--- a/application/language/dutch/kalkun_lang.php
+++ b/application/language/dutch/kalkun_lang.php
@@ -193,6 +193,17 @@ $lang['kalkun_compose_import_file'] = "Importeer van bestand";
 $lang['kalkun_compose_counter_character'] = "tekens";
 $lang['kalkun_compose_counter_message'] = "bericht";
 
+// Messages controller
+$lang['kalkun_msg_login_success_data_lost'] = "Login successful. But %s data lost during login process.";
+$lang['kalkun_msg_go_back_and_submit'] = 'Please <a href="%s" onclick="goBackToForm()">go back to your form</a> and submit again.';
+$lang['kalkun_msg_login_success_resubmit'] = "Login successful. Resubmitting Form.";
+$lang['kalkun_msg_outgoing_disabled'] = "Outgoing SMS disabled";
+$lang['kalkun_msg_number_in_DND'] = "A number was found in DND Resitry. SMS sending was skipped for it.";
+$lang['kalkun_msg_delivered_to_user_inbox'] = "Message successfully delivered to user inbox";
+$lang['kalkun_msg_moved_to_outbox'] = "Your message has been moved to outbox and is ready for delivery";
+$lang['kalkun_msg_no_numberfound'] = "No number found. SMS not sent";
+$lang['kalkun_msg_only_admin_can_permanently_delete'] = "Only administrators can permanently delete messages";
+
 // Setting
 $lang['kalkun_setting_passwd_current'] = "Huidig Wachtwoord";
 $lang['kalkun_setting_passwd_forgot'] = "Wachtwoord Vergeten?";

--- a/application/language/english/kalkun_lang.php
+++ b/application/language/english/kalkun_lang.php
@@ -193,6 +193,17 @@ $lang['kalkun_compose_import_file'] = "Import from file";
 $lang['kalkun_compose_counter_character'] = "characters";
 $lang['kalkun_compose_counter_message'] = "message";
 
+// Messages controller
+$lang['kalkun_msg_login_success_data_lost'] = "Login successful. But %s data lost during login process.";
+$lang['kalkun_msg_go_back_and_submit'] = 'Please <a href="%s" onclick="goBackToForm()">go back to your form</a> and submit again.';
+$lang['kalkun_msg_login_success_resubmit'] = "Login successful. Resubmitting Form.";
+$lang['kalkun_msg_outgoing_disabled'] = "Outgoing SMS disabled";
+$lang['kalkun_msg_number_in_DND'] = "A number was found in DND Resitry. SMS sending was skipped for it.";
+$lang['kalkun_msg_delivered_to_user_inbox'] = "Message successfully delivered to user inbox";
+$lang['kalkun_msg_moved_to_outbox'] = "Your message has been moved to outbox and is ready for delivery";
+$lang['kalkun_msg_no_numberfound'] = "No number found. SMS not sent";
+$lang['kalkun_msg_only_admin_can_permanently_delete'] = "Only administrators can permanently delete messages";
+
 // Setting
 $lang['kalkun_setting_passwd_current'] = "Current Password";
 $lang['kalkun_setting_passwd_forgot'] = "Forgot your password?";

--- a/application/language/finnish/kalkun_lang.php
+++ b/application/language/finnish/kalkun_lang.php
@@ -193,6 +193,17 @@ $lang['kalkun_compose_import_file'] = "Tuo tiedostosta";
 $lang['kalkun_compose_counter_character'] = "merkkiä";
 $lang['kalkun_compose_counter_message'] = "viesti";
 
+// Messages controller
+$lang['kalkun_msg_login_success_data_lost'] = "Login successful. But %s data lost during login process.";
+$lang['kalkun_msg_go_back_and_submit'] = 'Please <a href="%s" onclick="goBackToForm()">go back to your form</a> and submit again.';
+$lang['kalkun_msg_login_success_resubmit'] = "Login successful. Resubmitting Form.";
+$lang['kalkun_msg_outgoing_disabled'] = "Outgoing SMS disabled";
+$lang['kalkun_msg_number_in_DND'] = "A number was found in DND Resitry. SMS sending was skipped for it.";
+$lang['kalkun_msg_delivered_to_user_inbox'] = "Message successfully delivered to user inbox";
+$lang['kalkun_msg_moved_to_outbox'] = "Your message has been moved to outbox and is ready for delivery";
+$lang['kalkun_msg_no_numberfound'] = "No number found. SMS not sent";
+$lang['kalkun_msg_only_admin_can_permanently_delete'] = "Only administrators can permanently delete messages";
+
 // Setting
 $lang['kalkun_setting_passwd_current'] = "Nykyinen salasana";
 $lang['kalkun_setting_passwd_forgot'] = "Unohditko salasanasi?";

--- a/application/language/french/kalkun_lang.php
+++ b/application/language/french/kalkun_lang.php
@@ -190,8 +190,19 @@ $lang['kalkun_delete_all_message_now'] = "Supprimer tous les messages";
 $lang['kalkun_contact_del_title'] = "Confirmation de la suppression du contact";
 $lang['kalkun_compose_valid_url'] = "L'URL doit étre valide";
 $lang['kalkun_compose_import_file'] = "Importer à partir du fichier";
-$lang['kalkun_compose_counter_character'] = "caractéres";
+$lang['kalkun_compose_counter_character'] = "caractères";
 $lang['kalkun_compose_counter_message'] = "message";
+
+// Messages controller
+$lang['kalkun_msg_login_success_data_lost'] = "Login réussi. Mais données %s perdues durant le processus de login.";
+$lang['kalkun_msg_go_back_and_submit'] = 'Veuillez <a href="%s" onclick="goBackToForm()">retourner à votre formulaire</a> et le soumettre à nouveau.';
+$lang['kalkun_msg_login_success_resubmit'] = "Login réussi. Le formulaire est à nouveau soumis.";
+$lang['kalkun_msg_outgoing_disabled'] = "SMS sortants désactivés";
+$lang['kalkun_msg_number_in_DND'] = "Un numéro a été trouvé dans le registre DND. L'envoi est annulé pour celui-ci.";
+$lang['kalkun_msg_delivered_to_user_inbox'] = "Message placé avec succès dans la boîte de réception de l'utilisateur";
+$lang['kalkun_msg_moved_to_outbox'] = "Message placé dans la boite d'envoi et prêt à être envoyé";
+$lang['kalkun_msg_no_numberfound'] = "Pas de numéro trouvé. SMS non envoyé";
+$lang['kalkun_msg_only_admin_can_permanently_delete'] = "Seuls les administrateurs peuvent supprimer des messages de façon permanente";
 
 // Setting
 $lang['kalkun_setting_passwd_current'] = "Mot de passe actuel";

--- a/application/language/german/kalkun_lang.php
+++ b/application/language/german/kalkun_lang.php
@@ -193,6 +193,17 @@ $lang['kalkun_compose_import_file'] = "Von Datei importieren";
 $lang['kalkun_compose_counter_character'] = "Zeichen";
 $lang['kalkun_compose_counter_message'] = "Nachricht";
 
+// Messages controller
+$lang['kalkun_msg_login_success_data_lost'] = "Login successful. But %s data lost during login process.";
+$lang['kalkun_msg_go_back_and_submit'] = 'Please <a href="%s" onclick="goBackToForm()">go back to your form</a> and submit again.';
+$lang['kalkun_msg_login_success_resubmit'] = "Login successful. Resubmitting Form.";
+$lang['kalkun_msg_outgoing_disabled'] = "Outgoing SMS disabled";
+$lang['kalkun_msg_number_in_DND'] = "A number was found in DND Resitry. SMS sending was skipped for it.";
+$lang['kalkun_msg_delivered_to_user_inbox'] = "Message successfully delivered to user inbox";
+$lang['kalkun_msg_moved_to_outbox'] = "Your message has been moved to outbox and is ready for delivery";
+$lang['kalkun_msg_no_numberfound'] = "No number found. SMS not sent";
+$lang['kalkun_msg_only_admin_can_permanently_delete'] = "Only administrators can permanently delete messages";
+
 // Setting
 $lang['kalkun_setting_passwd_current'] = "Aktuelles Passwort";
 $lang['kalkun_setting_passwd_forgot'] = "Passswort vergessen?";

--- a/application/language/hungarian/kalkun_lang.php
+++ b/application/language/hungarian/kalkun_lang.php
@@ -194,6 +194,17 @@ $lang['kalkun_compose_import_file'] = "Importálás fájlból";
 $lang['kalkun_compose_counter_character'] = "karakter";
 $lang['kalkun_compose_counter_message'] = "üzenet";
 
+// Messages controller
+$lang['kalkun_msg_login_success_data_lost'] = "Login successful. But %s data lost during login process.";
+$lang['kalkun_msg_go_back_and_submit'] = 'Please <a href="%s" onclick="goBackToForm()">go back to your form</a> and submit again.';
+$lang['kalkun_msg_login_success_resubmit'] = "Login successful. Resubmitting Form.";
+$lang['kalkun_msg_outgoing_disabled'] = "Outgoing SMS disabled";
+$lang['kalkun_msg_number_in_DND'] = "A number was found in DND Resitry. SMS sending was skipped for it.";
+$lang['kalkun_msg_delivered_to_user_inbox'] = "Message successfully delivered to user inbox";
+$lang['kalkun_msg_moved_to_outbox'] = "Your message has been moved to outbox and is ready for delivery";
+$lang['kalkun_msg_no_numberfound'] = "No number found. SMS not sent";
+$lang['kalkun_msg_only_admin_can_permanently_delete'] = "Only administrators can permanently delete messages";
+
 // Setting
 $lang['kalkun_setting_passwd_current'] = "Aktuális jelszó";
 $lang['kalkun_setting_passwd_forgot'] = "Elfelejtette a jelszavát?";

--- a/application/language/indonesian/kalkun_lang.php
+++ b/application/language/indonesian/kalkun_lang.php
@@ -193,6 +193,17 @@ $lang['kalkun_compose_import_file'] = "Impor dari dokumen";
 $lang['kalkun_compose_counter_character'] = "karakter";
 $lang['kalkun_compose_counter_message'] = "pesan";
 
+// Messages controller
+$lang['kalkun_msg_login_success_data_lost'] = "Login successful. But %s data lost during login process.";
+$lang['kalkun_msg_go_back_and_submit'] = 'Please <a href="%s" onclick="goBackToForm()">go back to your form</a> and submit again.';
+$lang['kalkun_msg_login_success_resubmit'] = "Login successful. Resubmitting Form.";
+$lang['kalkun_msg_outgoing_disabled'] = "Outgoing SMS disabled";
+$lang['kalkun_msg_number_in_DND'] = "A number was found in DND Resitry. SMS sending was skipped for it.";
+$lang['kalkun_msg_delivered_to_user_inbox'] = "Message successfully delivered to user inbox";
+$lang['kalkun_msg_moved_to_outbox'] = "Your message has been moved to outbox and is ready for delivery";
+$lang['kalkun_msg_no_numberfound'] = "No number found. SMS not sent";
+$lang['kalkun_msg_only_admin_can_permanently_delete'] = "Only administrators can permanently delete messages";
+
 // Setting
 $lang['kalkun_setting_passwd_current'] = "Password saat ini";
 $lang['kalkun_setting_passwd_forgot'] = "Lupa password Anda?";

--- a/application/language/italian/kalkun_lang.php
+++ b/application/language/italian/kalkun_lang.php
@@ -193,6 +193,17 @@ $lang['kalkun_compose_import_file'] = "Import from file";
 $lang['kalkun_compose_counter_character'] = "characters";
 $lang['kalkun_compose_counter_message'] = "message";
 
+// Messages controller
+$lang['kalkun_msg_login_success_data_lost'] = "Login successful. But %s data lost during login process.";
+$lang['kalkun_msg_go_back_and_submit'] = 'Please <a href="%s" onclick="goBackToForm()">go back to your form</a> and submit again.';
+$lang['kalkun_msg_login_success_resubmit'] = "Login successful. Resubmitting Form.";
+$lang['kalkun_msg_outgoing_disabled'] = "Outgoing SMS disabled";
+$lang['kalkun_msg_number_in_DND'] = "A number was found in DND Resitry. SMS sending was skipped for it.";
+$lang['kalkun_msg_delivered_to_user_inbox'] = "Message successfully delivered to user inbox";
+$lang['kalkun_msg_moved_to_outbox'] = "Your message has been moved to outbox and is ready for delivery";
+$lang['kalkun_msg_no_numberfound'] = "No number found. SMS not sent";
+$lang['kalkun_msg_only_admin_can_permanently_delete'] = "Only administrators can permanently delete messages";
+
 // Setting
 $lang['kalkun_setting_passwd_current'] = "Current Password";
 $lang['kalkun_setting_passwd_forgot'] = "Forgot your password?";

--- a/application/language/polish/kalkun_lang.php
+++ b/application/language/polish/kalkun_lang.php
@@ -193,6 +193,17 @@ $lang['kalkun_compose_import_file'] = "Import z pliku";
 $lang['kalkun_compose_counter_character'] = "znaków";
 $lang['kalkun_compose_counter_message'] = "wiadomości";
 
+// Messages controller
+$lang['kalkun_msg_login_success_data_lost'] = "Login successful. But %s data lost during login process.";
+$lang['kalkun_msg_go_back_and_submit'] = 'Please <a href="%s" onclick="goBackToForm()">go back to your form</a> and submit again.';
+$lang['kalkun_msg_login_success_resubmit'] = "Login successful. Resubmitting Form.";
+$lang['kalkun_msg_outgoing_disabled'] = "Outgoing SMS disabled";
+$lang['kalkun_msg_number_in_DND'] = "A number was found in DND Resitry. SMS sending was skipped for it.";
+$lang['kalkun_msg_delivered_to_user_inbox'] = "Message successfully delivered to user inbox";
+$lang['kalkun_msg_moved_to_outbox'] = "Your message has been moved to outbox and is ready for delivery";
+$lang['kalkun_msg_no_numberfound'] = "No number found. SMS not sent";
+$lang['kalkun_msg_only_admin_can_permanently_delete'] = "Only administrators can permanently delete messages";
+
 // Setting
 $lang['kalkun_setting_passwd_current'] = "Aktualne hasło";
 $lang['kalkun_setting_passwd_forgot'] = "Zapomniałem hasła";

--- a/application/language/portuguese/kalkun_lang.php
+++ b/application/language/portuguese/kalkun_lang.php
@@ -195,6 +195,17 @@ $lang['kalkun_compose_import_file'] = "Importar ficheiro";
 $lang['kalkun_compose_counter_character'] = "caracteres";
 $lang['kalkun_compose_counter_message'] = "mensagem";
 
+// Messages controller
+$lang['kalkun_msg_login_success_data_lost'] = "Login successful. But %s data lost during login process.";
+$lang['kalkun_msg_go_back_and_submit'] = 'Please <a href="%s" onclick="goBackToForm()">go back to your form</a> and submit again.';
+$lang['kalkun_msg_login_success_resubmit'] = "Login successful. Resubmitting Form.";
+$lang['kalkun_msg_outgoing_disabled'] = "Outgoing SMS disabled";
+$lang['kalkun_msg_number_in_DND'] = "A number was found in DND Resitry. SMS sending was skipped for it.";
+$lang['kalkun_msg_delivered_to_user_inbox'] = "Message successfully delivered to user inbox";
+$lang['kalkun_msg_moved_to_outbox'] = "Your message has been moved to outbox and is ready for delivery";
+$lang['kalkun_msg_no_numberfound'] = "No number found. SMS not sent";
+$lang['kalkun_msg_only_admin_can_permanently_delete'] = "Only administrators can permanently delete messages";
+
 // Setting
 $lang['kalkun_setting_passwd_current'] = "Password Atual";
 $lang['kalkun_setting_passwd_forgot'] = "Esqueceu a password?";

--- a/application/language/russian/kalkun_lang.php
+++ b/application/language/russian/kalkun_lang.php
@@ -193,6 +193,17 @@ $lang['kalkun_compose_import_file'] = "Import from file";
 $lang['kalkun_compose_counter_character'] = "characters";
 $lang['kalkun_compose_counter_message'] = "message";
 
+// Messages controller
+$lang['kalkun_msg_login_success_data_lost'] = "Login successful. But %s data lost during login process.";
+$lang['kalkun_msg_go_back_and_submit'] = 'Please <a href="%s" onclick="goBackToForm()">go back to your form</a> and submit again.';
+$lang['kalkun_msg_login_success_resubmit'] = "Login successful. Resubmitting Form.";
+$lang['kalkun_msg_outgoing_disabled'] = "Outgoing SMS disabled";
+$lang['kalkun_msg_number_in_DND'] = "A number was found in DND Resitry. SMS sending was skipped for it.";
+$lang['kalkun_msg_delivered_to_user_inbox'] = "Message successfully delivered to user inbox";
+$lang['kalkun_msg_moved_to_outbox'] = "Your message has been moved to outbox and is ready for delivery";
+$lang['kalkun_msg_no_numberfound'] = "No number found. SMS not sent";
+$lang['kalkun_msg_only_admin_can_permanently_delete'] = "Only administrators can permanently delete messages";
+
 // Setting
 $lang['kalkun_setting_passwd_current'] = "Current Password";
 $lang['kalkun_setting_passwd_forgot'] = "Forgot your password?";

--- a/application/language/slovak/kalkun_lang.php
+++ b/application/language/slovak/kalkun_lang.php
@@ -193,6 +193,17 @@ $lang['kalkun_compose_import_file'] = "Import zo súboru";
 $lang['kalkun_compose_counter_character'] = "znakov";
 $lang['kalkun_compose_counter_message'] = "správa";
 
+// Messages controller
+$lang['kalkun_msg_login_success_data_lost'] = "Login successful. But %s data lost during login process.";
+$lang['kalkun_msg_go_back_and_submit'] = 'Please <a href="%s" onclick="goBackToForm()">go back to your form</a> and submit again.';
+$lang['kalkun_msg_login_success_resubmit'] = "Login successful. Resubmitting Form.";
+$lang['kalkun_msg_outgoing_disabled'] = "Outgoing SMS disabled";
+$lang['kalkun_msg_number_in_DND'] = "A number was found in DND Resitry. SMS sending was skipped for it.";
+$lang['kalkun_msg_delivered_to_user_inbox'] = "Message successfully delivered to user inbox";
+$lang['kalkun_msg_moved_to_outbox'] = "Your message has been moved to outbox and is ready for delivery";
+$lang['kalkun_msg_no_numberfound'] = "No number found. SMS not sent";
+$lang['kalkun_msg_only_admin_can_permanently_delete'] = "Only administrators can permanently delete messages";
+
 // Setting
 $lang['kalkun_setting_passwd_current'] = "Terajšie heslo";
 $lang['kalkun_setting_passwd_forgot'] = "Zabudli ste heslo?";

--- a/application/language/spanish/kalkun_lang.php
+++ b/application/language/spanish/kalkun_lang.php
@@ -193,6 +193,17 @@ $lang['kalkun_compose_import_file'] = "Importar desde archivo";
 $lang['kalkun_compose_counter_character'] = "caracteres";
 $lang['kalkun_compose_counter_message'] = "mensaje";
 
+// Messages controller
+$lang['kalkun_msg_login_success_data_lost'] = "Login successful. But %s data lost during login process.";
+$lang['kalkun_msg_go_back_and_submit'] = 'Please <a href="%s" onclick="goBackToForm()">go back to your form</a> and submit again.';
+$lang['kalkun_msg_login_success_resubmit'] = "Login successful. Resubmitting Form.";
+$lang['kalkun_msg_outgoing_disabled'] = "Outgoing SMS disabled";
+$lang['kalkun_msg_number_in_DND'] = "A number was found in DND Resitry. SMS sending was skipped for it.";
+$lang['kalkun_msg_delivered_to_user_inbox'] = "Message successfully delivered to user inbox";
+$lang['kalkun_msg_moved_to_outbox'] = "Your message has been moved to outbox and is ready for delivery";
+$lang['kalkun_msg_no_numberfound'] = "No number found. SMS not sent";
+$lang['kalkun_msg_only_admin_can_permanently_delete'] = "Only administrators can permanently delete messages";
+
 // Setting
 $lang['kalkun_setting_passwd_current'] = "Clave actual";
 $lang['kalkun_setting_passwd_forgot'] = "¿Olvid&oacute; su clave?";

--- a/application/language/turkish/kalkun_lang.php
+++ b/application/language/turkish/kalkun_lang.php
@@ -193,6 +193,17 @@ $lang['kalkun_compose_import_file'] = "Import from file";
 $lang['kalkun_compose_counter_character'] = "characters";
 $lang['kalkun_compose_counter_message'] = "message";
 
+// Messages controller
+$lang['kalkun_msg_login_success_data_lost'] = "Login successful. But %s data lost during login process.";
+$lang['kalkun_msg_go_back_and_submit'] = 'Please <a href="%s" onclick="goBackToForm()">go back to your form</a> and submit again.';
+$lang['kalkun_msg_login_success_resubmit'] = "Login successful. Resubmitting Form.";
+$lang['kalkun_msg_outgoing_disabled'] = "Outgoing SMS disabled";
+$lang['kalkun_msg_number_in_DND'] = "A number was found in DND Resitry. SMS sending was skipped for it.";
+$lang['kalkun_msg_delivered_to_user_inbox'] = "Message successfully delivered to user inbox";
+$lang['kalkun_msg_moved_to_outbox'] = "Your message has been moved to outbox and is ready for delivery";
+$lang['kalkun_msg_no_numberfound'] = "No number found. SMS not sent";
+$lang['kalkun_msg_only_admin_can_permanently_delete'] = "Only administrators can permanently delete messages";
+
 // Setting
 $lang['kalkun_setting_passwd_current'] = "Current Password";
 $lang['kalkun_setting_passwd_forgot'] = "Forgot your password?";

--- a/application/views/main/form_result.php
+++ b/application/views/main/form_result.php
@@ -1,0 +1,19 @@
+<?php 
+$this->load->helper('html');
+echo doctype('html5');?>
+<html>
+<head>
+<title>Kalkun / Form result</title>
+<meta http-equiv="content-type" content="text/html;charset=utf-8" />
+<?php echo link_tag($this->config->item('img_path').'icon.ico', 'shortcut icon', 'image/ico');?>
+<?php echo link_tag($this->config->item('css_path').'base.css');?>
+<style>
+@import url("<?php echo $this->config->item('css_path');?>blue.css");
+</style>	
+</head>
+<body>
+<p>
+<?php echo $result; ?>
+</p>
+</body>
+</html>

--- a/application/views/main/info_message.php
+++ b/application/views/main/info_message.php
@@ -1,15 +1,15 @@
-<?php 
+<?php
 $this->load->helper('html');
 echo doctype('html5');?>
 <html>
 <head>
-<title>Kalkun / Form result</title>
+<title>Kalkun / Info message</title>
 <meta http-equiv="content-type" content="text/html;charset=utf-8" />
 <?php echo link_tag($this->config->item('img_path').'icon.ico', 'shortcut icon', 'image/ico');?>
 <?php echo link_tag($this->config->item('css_path').'base.css');?>
 <style>
 @import url("<?php echo $this->config->item('css_path');?>blue.css");
-</style>	
+</style>
 </head>
 <body>
 <p>


### PR DESCRIPTION
 * When calling "compose_process" from a form within a browser there were 2 issues:
   - After logging-in the POSTed data was lost and thus nothing was sent
   - If POSTing while already logged-in, the return message was displayed
     on the same URL, what could lead to a re-submission if the user
     refreshed the page.

 * This creates a wrapper method calling compose_process that will fix it

 * Now, when posting to /index.php/messages/compose_process_api before the user
   is logged-in, this will redirect the user to the URL containing the form
   he posted.
    - If in the process the POSTed data is lost, the user gets redirected by
      using the window.history.go function instead of the referrer
      so that the data of the form is not lost.
    - If the POSTed data is kept, then it is automatically submitted

 * After submission, the user is redirected to a new page showing the form result.