### PR TITLE
Create tables 'pbk' & 'pbk_groups' for SQLite3

### DIFF
--- a/media/db/sqlite_kalkun.sql
+++ b/media/db/sqlite_kalkun.sql
@@ -72,6 +72,23 @@ ALTER TABLE "inbox" ADD COLUMN "readed" TEXT NOT NULL DEFAULT 'false';
 
 ALTER TABLE "sentitems" ADD COLUMN "id_folder" INTEGER NOT NULL DEFAULT 3;
 
+-- --------------------------------------------------------
+-- pbk & pbk_groups tables have been removed from gammu-smsd Databse
+-- in schema version 16 (corresponding to gammu 1.37.90)
+-- This will create them as they used to be created by gammu.
+
+CREATE TABLE pbk (
+  ID INTEGER PRIMARY KEY AUTOINCREMENT,
+  GroupID INTEGER NOT NULL DEFAULT '-1',
+  Name TEXT NOT NULL,
+  Number TEXT NOT NULL
+);
+
+CREATE TABLE pbk_groups (
+  Name TEXT NOT NULL,
+  ID INTEGER PRIMARY KEY AUTOINCREMENT
+);
+
 ALTER TABLE "pbk" ADD COLUMN "id_user" INTEGER NULL;
 ALTER TABLE "pbk" ADD COLUMN "is_public" TEXT NOT NULL DEFAULT 'false';
 


### PR DESCRIPTION
pbk & pbk_groups tables have been removed from gammu-smsd Databse
in schema version 16 (corresponding to gammu 1.37.90)
This will create them as they used to be created by gammu.

SQLite3 scripts should now be in line with those of Postgresql & mysql