### PR TITLE
update session management to conform to ci3 and mention SQLite

### DIFF
--- a/application/config/config.php
+++ b/application/config/config.php
@@ -236,21 +236,25 @@ $config['encryption_key'] = "F0af18413d1c9e03A6d8d1273160f5Ed";
 |--------------------------------------------------------------------------
 |
 | 'session_cookie_name' = the name you want for the cookie
-| 'encrypt_sess_cookie' = TRUE/FALSE (boolean).  Whether to encrypt the cookie
 | 'session_expiration'  = the number of SECONDS you want the session to last.
 |  by default sessions last 7200 seconds (two hours).  Set to zero for no expiration.
 | 'time_to_update'		= how many seconds between CI refreshing Session Information
 |
+| If you use SQLite3 you can't use driver "database"
+| see: https://codeigniter.com/userguide3/libraries/sessions.html#session-drivers
+| Set config this way:
+| $config['sess_driver']     = 'files';
+| $config['sess_save_path']  = 'session_save_path()';
+|
 */
+
 $config['sess_driver'] = 'database'; // Change files to database
 $config['sess_cookie_name']		= 'kalkun_ci_session';
 $config['sess_expiration']		= 1209600; // 2 weeks
-$config['sess_encrypt_cookie']	= TRUE;
-$config['sess_use_database']	= FALSE;
-$config['sess_table_name']		= 'ci_sessions';
+$config['sess_save_path']		= 'ci_sessions';
 $config['sess_match_ip']		= FALSE;
-$config['sess_match_useragent']	= FALSE;
 $config['sess_time_to_update'] 	= 300;
+$config['sess_regenerate_destroy'] 	= FALSE;
 
 /*
 |--------------------------------------------------------------------------

--- a/media/db/mysql_kalkun.sql
+++ b/media/db/mysql_kalkun.sql
@@ -321,11 +321,20 @@ CREATE TABLE IF NOT EXISTS `user_filters` (
   PRIMARY KEY (`id_filter`)
 ) ENGINE=MyISAM  DEFAULT CHARSET=latin1 AUTO_INCREMENT=1 ;
 
+-- --------------------------------------------------------
 
-CREATE TABLE `ci_sessions` (
-  `id` varchar(40) NOT NULL,
+--
+-- Table structure for table `ci_sessions`
+-- see: https://codeigniter.com/userguide3/libraries/sessions.html#database-driver
+--
+
+CREATE TABLE IF NOT EXISTS `ci_sessions` (
+  `id` varchar(128) NOT NULL,
   `ip_address` varchar(45) NOT NULL,
-  `timestamp` int(10) unsigned NOT NULL DEFAULT '0',
+  `timestamp` int(10) unsigned DEFAULT 0 NOT NULL,
   `data` blob NOT NULL,
   KEY `ci_sessions_timestamp` (`timestamp`)
-) DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
+);
+
+-- When sess_match_ip = FALSE
+ALTER TABLE ci_sessions ADD PRIMARY KEY (id);

--- a/media/db/pgsql_kalkun.sql
+++ b/media/db/pgsql_kalkun.sql
@@ -150,6 +150,13 @@ CREATE TABLE "user_filters" (
   "id_folder" integer NOT NULL
 );
 
+-- --------------------------------------------------------
+
+--
+-- Table structure for table `ci_sessions`
+-- see: https://codeigniter.com/userguide3/libraries/sessions.html#database-driver
+--
+
 CREATE TABLE "ci_sessions" (
     "id" varchar(128) NOT NULL,
     "ip_address" varchar(45) NOT NULL,
@@ -158,3 +165,6 @@ CREATE TABLE "ci_sessions" (
 );
 
 CREATE INDEX "ci_sessions_timestamp" ON "ci_sessions" ("timestamp");
+
+-- When sess_match_ip = FALSE
+ALTER TABLE ci_sessions ADD PRIMARY KEY (id);


### PR DESCRIPTION
- Some config parameters have been removed with ci3, so cleanup kalkun
- Update SQL scripts to conform ci3 recommendations found here
https://codeigniter.com/userguide3/libraries/sessions.html#database-driver
- Mention how to proceed with configuration when using SQLite3 as database,
since ci_sessions are only supported with MySQL & PostreSQL

This also fixes #190 