### PR TITLE
rest API: add possibility to set coding in the URL

### DIFF
--- a/application/plugins/rest_api/controllers/Rest_api.php
+++ b/application/plugins/rest_api/controllers/Rest_api.php
@@ -37,7 +37,7 @@ class Rest_api extends REST_Controller {
 	function send_sms_get()
 	{
 		$this->load->model(array('Kalkun_model', 'Message_model'));
-		$data['coding'] = 'default';
+		$data['coding'] = ($this->get('coding') == "unicode") ? $this->get('coding') : 'default';
 		$data['class'] = '1';
 		$data['dest'] = $this->get('phoneNumber');
 		$data['date'] = date('Y-m-d H:i:s');


### PR DESCRIPTION
If parameter is not set in the URL or is not "unicode" it will set "default"
Otherwise it will set the value for "coding" to unicode
To set coding to unicode, URL should contain
...&coding=unicode

**Fixes #213**