### PR TITLE
Fixed a few bugs, mostly ensuring correct handing UTF-8 with MySQL

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ You need to install and configure this first:
   * APC or APCu
 * PHP-CLI
 * PHP Composer
-* MySQL 5.1+ or PostgreSQL or SQLite3
+* MySQL 5.5.3+ or PostgreSQL or SQLite3
 * gammu-smsd (make sure it is already running and configured)
 
 ## Installation

--- a/application/config/database.php
+++ b/application/config/database.php
@@ -26,6 +26,7 @@
 |	['cachedir'] The path to the folder where cache files should be stored
 |	['char_set'] The character set used in communicating with the database
 |	['dbcollat'] The character collation used in communicating with the database
+| - NOTE: ['dbcollat'] is only used in the ‘MySQLi’ driver.
 |
 | The $active_group variable lets you choose which connection group to
 | make active.  By default there is only one group (the "default" group).
@@ -44,6 +45,8 @@ $db['default']['username'] = "root";
 $db['default']['password'] = "password";
 $db['default']['database'] = "kalkun";
 $db['default']['dbdriver'] = "mysqli";
+$db['default']['char_set'] = "utf8mb4";
+$db['default']['dbcollat'] = "utf8mb4_general_ci";
 
 // PostgreSQL
 // $db['default']['username'] = "postgres";
@@ -61,15 +64,10 @@ $db['default']['db_debug'] = TRUE;
 $db['default']['cache_on'] = FALSE;
 $db['default']['cachedir'] = "";
 
-if ($db['default']['dbdriver'] == "mysqli") {
-	$db['default']['char_set'] = "utf8mb4";
-	$db['default']['dbcollat'] = "utf8mb4_general_ci";
-}
-else {
+// Character set for non-MySQLi drivers
+if (strcasecmp($db['default']['dbdriver'], "mysqli") != 0) {
 	$db['default']['char_set'] = "utf8";
-  $db['default']['dbcollat'] = "utf8_general_ci";
 }
-
 
 /* End of file database.php */
 /* Location: ./application/config/database.php */

--- a/application/config/database.php
+++ b/application/config/database.php
@@ -60,8 +60,15 @@ $db['default']['pconnect'] = FALSE;
 $db['default']['db_debug'] = TRUE;
 $db['default']['cache_on'] = FALSE;
 $db['default']['cachedir'] = "";
-$db['default']['char_set'] = "utf8";
-$db['default']['dbcollat'] = "utf8_general_ci";
+
+if ($db['default']['dbdriver'] == "mysqli") {
+	$db['default']['char_set'] = "utf8mb4";
+	$db['default']['dbcollat'] = "utf8mb4_general_ci";
+}
+else {
+	$db['default']['char_set'] = "utf8";
+  $db['default']['dbcollat'] = "utf8_general_ci";
+}
 
 
 /* End of file database.php */

--- a/application/models/gateway/Gammu_model.php
+++ b/application/models/gateway/Gammu_model.php
@@ -189,9 +189,10 @@ class Gammu_model extends CI_Model {
 				'CreatorID' => $tmp_data['CreatorID'],
 				'SenderID' => $tmp_data['SenderID'],
 				'TextDecoded' => $tmp_data['message'],
-                'RelativeValidity' => $tmp_data['validity'],
-				'DeliveryReport' => $tmp_data['delivery_report']			
-				);
+				'RelativeValidity' => $tmp_data['validity'],
+				'DeliveryReport' => $tmp_data['delivery_report'],
+				'CreatorID' => '🦃 Kalkun '.$this->config->item('kalkun_version')	
+		);
 					
 		if($tmp_data['option']=='multipart')
 		{

--- a/application/views/main/install/requirement_check.php
+++ b/application/views/main/install/requirement_check.php
@@ -65,6 +65,11 @@
 	</tr>
 
 	<tr>
+		<td colspan="3">Ctype</td>
+		<td class="right"><?php if(extension_loaded('ctype')) echo "<span class=\"green\">OK</span>"; else { echo "<span class=\"red\">Not OK</span>"; $error++; }?></td>
+	</tr>
+
+	<tr>
 		<td colspan="3" class="bottom">APC or APCu</td>
 		<td class="right bottom"><?php if(extension_loaded('apc') || extension_loaded('apcu')) echo "<span class=\"green\">OK</span>"; else { echo "<span class=\"red\">Not OK</span>"; $error++; }?></td>
 	</tr>

--- a/application/views/main/install/requirement_check.php
+++ b/application/views/main/install/requirement_check.php
@@ -1,6 +1,6 @@
 <?php $error=0; ?>
-<h2>Requirement check</h2>
-<p>This page show you wheteher your system environment is good enough or not to run Kalkun.</p>
+<h2>Requirements check</h2>
+<p>This page will check if your system is compatible with Kalkun.</p>
 
 <table border="0" cellspacing="0" cellpadding="0" class="simpletable">
 	<tr>
@@ -32,7 +32,7 @@
 	<tr>
 		<td colspan="3">
 		<?php $db_property = get_database_property($database_driver); ?>
-		<?php echo $db_property['human']; ?> <i>(Readed from database configuration)</i>
+		<?php echo $db_property['human']; ?> <i>(Read from database configuration)</i>
 		</td>
 		<td class="right">
 		<?php
@@ -45,32 +45,32 @@
 	</tr>
 
 	<tr>
-		<td colspan="3">Session</td>
+		<td colspan="3">Session - Session Handling</td>
 		<td class="right"><?php if(extension_loaded('session')) echo "<span class=\"green\">OK</span>"; else { echo "<span class=\"red\">Not OK</span>"; $error++; }?></td>
 	</tr>
 
 	<tr>
-		<td colspan="3">Hash</td>
+		<td colspan="3">HASH - HASH Message Digest Framework</td>
 		<td class="right"><?php if(extension_loaded('hash')) echo "<span class=\"green\">OK</span>"; else { echo "<span class=\"red\">Not OK</span>"; $error++; }?></td>
 	</tr>
 
 	<tr>
-		<td colspan="3">JSON</td>
+		<td colspan="3">JSON - JavaScript Object Notation</td>
 		<td class="right"><?php if(extension_loaded('json')) echo "<span class=\"green\">OK</span>"; else { echo "<span class=\"red\">Not OK</span>"; $error++; }?></td>
 	</tr>
 
 	<tr>
-		<td colspan="3">MBString</td>
+		<td colspan="3">MBString - Multibyte String</td>
 		<td class="right"><?php if(extension_loaded('mbstring')) echo "<span class=\"green\">OK</span>"; else { echo "<span class=\"red\">Not OK</span>"; $error++; }?></td>
 	</tr>
 
 	<tr>
-		<td colspan="3">Ctype</td>
+		<td colspan="3">Ctype - Character type checking</td>
 		<td class="right"><?php if(extension_loaded('ctype')) echo "<span class=\"green\">OK</span>"; else { echo "<span class=\"red\">Not OK</span>"; $error++; }?></td>
 	</tr>
 
 	<tr>
-		<td colspan="3" class="bottom">APC or APCu</td>
+		<td colspan="3" class="bottom">APC or APCu - APC User Cache</td>
 		<td class="right bottom"><?php if(extension_loaded('apc') || extension_loaded('apcu')) echo "<span class=\"green\">OK</span>"; else { echo "<span class=\"red\">Not OK</span>"; $error++; }?></td>
 	</tr>
 </table>
@@ -79,12 +79,12 @@
 
 <?php if($error>0): ?>
 <div>
-<p>Ooopss, looks like your system is not good enough to run Kalkun, please provide all requirement above.</p>
+<p>Unfortunately, your system does not meet the minimum requirements to run Kalkun. Please ensure your system meets the above requirements and refresh this page.</p>
 </div>
 
 <?php else: ?>
 <div>
-<p>Looks like everything is OK, let's continue.</p>
+<p>Your system is compatible with Kalkun.</p>
 <p><a href="<?php echo site_url();?>/install" class="button">&lsaquo; Back</a>
 <a href="<?php echo site_url();?>/install/database_setup" class="button">Next &rsaquo;</a></p>
 </div>

--- a/media/db/mysql_kalkun.sql
+++ b/media/db/mysql_kalkun.sql
@@ -27,7 +27,7 @@ SET SQL_MODE="NO_AUTO_VALUE_ON_ZERO";
 
 CREATE TABLE IF NOT EXISTS `kalkun` (
   `version` text NOT NULL
-) DEFAULT CHARSET=utf8;
+) DEFAULT CHARSET=utf8mb4;
 
 -- --------------------------------------------------------
 
@@ -42,7 +42,7 @@ CREATE TABLE IF NOT EXISTS `sms_used` (
   `out_sms_count` int(11) NOT NULL DEFAULT '0',
   `in_sms_count` int(11) NOT NULL DEFAULT '0',
   PRIMARY KEY (`id_sms_used`)
-)  DEFAULT CHARSET=utf8 ;
+)  DEFAULT CHARSET=utf8mb4 ;
 
 -- --------------------------------------------------------
 
@@ -60,7 +60,7 @@ CREATE TABLE IF NOT EXISTS `user` (
   PRIMARY KEY (`id_user`),
   UNIQUE KEY `username` (`username`),
   UNIQUE KEY `phone_number` (`phone_number`)
-)  DEFAULT CHARSET=utf8 AUTO_INCREMENT=2 ;
+)  DEFAULT CHARSET=utf8mb4 AUTO_INCREMENT=2 ;
 
 --
 -- Dumping data for table `user`
@@ -81,7 +81,7 @@ CREATE TABLE IF NOT EXISTS `user_folders` (
   `name` varchar(50) NOT NULL,
   `id_user` int(11) NOT NULL,
   PRIMARY KEY (`id_folder`)
-)  DEFAULT CHARSET=utf8 AUTO_INCREMENT=11 ;
+)  DEFAULT CHARSET=utf8mb4 AUTO_INCREMENT=11 ;
 
 --
 -- Dumping data for table `user_folders`
@@ -106,7 +106,7 @@ CREATE TABLE IF NOT EXISTS `user_inbox` (
   `id_user` int(11) NOT NULL,
   `trash` tinyint(1) NOT NULL DEFAULT '0',
   PRIMARY KEY (`id_inbox`)
-) DEFAULT CHARSET=utf8;
+) DEFAULT CHARSET=utf8mb4;
 
 -- --------------------------------------------------------
 
@@ -118,7 +118,7 @@ CREATE TABLE IF NOT EXISTS `user_outbox` (
   `id_outbox` int(11) NOT NULL,
   `id_user` int(11) NOT NULL,
   PRIMARY KEY (`id_outbox`)
-) DEFAULT CHARSET=utf8;
+) DEFAULT CHARSET=utf8mb4;
 
 -- --------------------------------------------------------
 
@@ -131,7 +131,7 @@ CREATE TABLE IF NOT EXISTS `user_sentitems` (
   `id_user` int(11) NOT NULL,
   `trash` tinyint(1) NOT NULL DEFAULT '0',
   PRIMARY KEY (`id_sentitems`)
-) DEFAULT CHARSET=utf8;
+) DEFAULT CHARSET=utf8mb4;
 
 -- --------------------------------------------------------
 
@@ -151,7 +151,7 @@ CREATE TABLE IF NOT EXISTS `user_settings` (
   `conversation_sort` enum('asc','desc') NOT NULL DEFAULT 'asc',
   `country_code` varchar(2) NOT NULL DEFAULT 'US',
   PRIMARY KEY (`id_user`)
-) DEFAULT CHARSET=utf8;
+) DEFAULT CHARSET=utf8mb4;
 
 --
 -- Dumping data for table `user_settings`
@@ -237,7 +237,7 @@ CREATE TABLE IF NOT EXISTS `user_group` (
   `id_pbk_groups` int(11) NOT NULL,
   `id_user` int(11) NOT NULL,
   PRIMARY KEY (`id_group`)
-)  DEFAULT CHARSET=utf8 ;
+)  DEFAULT CHARSET=utf8mb4 ;
 
 
 -- --------------------------------------------------------
@@ -252,7 +252,7 @@ CREATE TABLE IF NOT EXISTS `user_templates` (
   `Name` varchar(64) NOT NULL,
   `Message` text NOT NULL,
   PRIMARY KEY (`id_template`)
-)  DEFAULT CHARSET=utf8 ;
+)  DEFAULT CHARSET=utf8mb4 ;
 
 
 -- --------------------------------------------------------
@@ -262,10 +262,10 @@ CREATE TABLE IF NOT EXISTS `user_templates` (
 --
 
 CREATE TABLE `b8_wordlist` (
-  `token` varchar(255) character set utf8 collate utf8_bin NOT NULL,
+  `token` varchar(255) character set utf8mb4 collate utf8mb4_bin NOT NULL,
   `count` varchar(255) default NULL,
   PRIMARY KEY  (`token`)
-) DEFAULT CHARSET=utf8;
+) DEFAULT CHARSET=utf8mb4;
 
 INSERT INTO `b8_wordlist` VALUES ('bayes*dbversion', '2');
 INSERT INTO `b8_wordlist` VALUES ('bayes*texts.ham', '0');
@@ -289,7 +289,7 @@ CREATE TABLE IF NOT EXISTS `plugins` (
   `plugin_data` longtext,
   PRIMARY KEY (`plugin_id`),
   UNIQUE KEY `plugin_index` (`plugin_system_name`) USING BTREE
-)  DEFAULT CHARSET=utf8;
+)  DEFAULT CHARSET=utf8mb4;
 
 
 -- --------------------------------------------------------
@@ -303,7 +303,7 @@ CREATE TABLE IF NOT EXISTS `user_forgot_password` (
   `token` varchar(255) NOT NULL,
   `valid_until` datetime NOT NULL,
   PRIMARY KEY (`id_user`)
-) DEFAULT CHARSET=utf8;
+) DEFAULT CHARSET=utf8mb4;
 
 
 -- --------------------------------------------------------
@@ -319,7 +319,7 @@ CREATE TABLE IF NOT EXISTS `user_filters` (
   `has_the_words` varchar(50) NOT NULL,
   `id_folder` int(11) NOT NULL,
   PRIMARY KEY (`id_filter`)
-)  DEFAULT CHARSET=utf8 AUTO_INCREMENT=1 ;
+)  DEFAULT CHARSET=utf8mb4 AUTO_INCREMENT=1 ;
 
 -- --------------------------------------------------------
 

--- a/media/db/mysql_kalkun.sql
+++ b/media/db/mysql_kalkun.sql
@@ -67,7 +67,7 @@ CREATE TABLE IF NOT EXISTS `user` (
 --
 
 INSERT INTO `user` (`id_user`, `username`, `realname`, `password`, `phone_number`, `level`) VALUES
-(1, 'kalkun', 'Kalkun SMS', '$2y$10$Sg0IxngRIIp1qNITM8kWa.aJ26w58F97ByTzDKoRF/dyzKcLfx226', '123456789', 'admin');
+(1, 'kalkun', 'Kalkun SMS', '$2y$10$sIXe0JiaTIOsC7OOnox5t.deuJwZoawd5QKpQlSNfywziTDHpmmyy', '123456789', 'admin');
 
 
 -- --------------------------------------------------------

--- a/media/db/mysql_upgrade_kalkun.sql
+++ b/media/db/mysql_upgrade_kalkun.sql
@@ -11,4 +11,4 @@ CREATE TABLE IF NOT EXISTS `user_filters` (
   `has_the_words` varchar(50) NOT NULL,
   `id_folder` int(11) NOT NULL,
   PRIMARY KEY (`id_filter`)
-) ;
+)  DEFAULT CHARSET=utf8 AUTO_INCREMENT=1 ;

--- a/media/db/mysql_upgrade_kalkun.sql
+++ b/media/db/mysql_upgrade_kalkun.sql
@@ -11,4 +11,4 @@ CREATE TABLE IF NOT EXISTS `user_filters` (
   `has_the_words` varchar(50) NOT NULL,
   `id_folder` int(11) NOT NULL,
   PRIMARY KEY (`id_filter`)
-)  DEFAULT CHARSET=utf8 AUTO_INCREMENT=1 ;
+)  DEFAULT CHARSET=utf8mb4 AUTO_INCREMENT=1 ;


### PR DESCRIPTION
- Added Kalkun signature to Gammu database when composing new messages
- Increased minimum MySQL version to 5.5.3
- Added full UTF-8 support in MySQL database and config - fixes #265
- Added PHP-Ctype detection on Installation - fixes #264
- Reset default password to ‘kalkun’
- MySQL upgrade now specifies the same character encoding as MySQL dump