### PR TITLE
Plugins: call install function on plugin only if plugin is installed

### DIFF
--- a/application/libraries/Plugins.php
+++ b/application/libraries/Plugins.php
@@ -555,7 +555,10 @@ class Plugins {
     public function trigger_activate_plugin($name)
     {
         // Call plugin activate function
-        @call_user_func($name."_activate");
+        if (function_exists($name."_install"))
+        {
+            @call_user_func($name."_activate");
+        }
     }
 
     /**
@@ -566,7 +569,10 @@ class Plugins {
     public function trigger_deactivate_plugin($name)
     {
         // Call our plugin deactivate function
-        @call_user_func($name."_deactivate");
+        if (function_exists($name."_install"))
+        {
+            @call_user_func($name."_deactivate");
+        }
     }
 
     /**
@@ -577,7 +583,10 @@ class Plugins {
     public function trigger_install_plugin($name)
     {
         // Call our plugin deactivate function
-        @call_user_func($name."_install");
+        if (function_exists($name."_install"))
+        {
+            @call_user_func($name."_install");
+        }
     }
 
     /**


### PR DESCRIPTION
For example, if the plugin is enabled, but the plugin is not installed anymore there was en error saying that the function doesn't exit. So skip gracefully the call. The user is informed that the plugin is not installed once he is on the plugin page