### PR TITLE
create variables as array in Plugins.php

### DIFF
--- a/application/libraries/Plugins.php
+++ b/application/libraries/Plugins.php
@@ -33,12 +33,12 @@ class Plugins {
     public static $instance;
     
     // Action statics
-    public static $actions;
+    public static $actions = [];
     public static $current_action;
     public static $run_actions;
     
     // Plugins
-    public static $plugins_pool;
+    public static $plugins_pool = [];
     public static $plugins_active;
     
     // Directory


### PR DESCRIPTION
Fixes:

Message: array_key_exists(): Argument #2 () must be of type array, null given
Filename: application/libraries/Plugins.php