### PR TITLE
call ldap_connect with 1 parameter

### DIFF
--- a/application/plugins/phonebook_ldap/config/phonebook_ldap.php
+++ b/application/plugins/phonebook_ldap/config/phonebook_ldap.php
@@ -15,8 +15,7 @@ defined('BASEPATH') OR exit('No direct script access allowed');
 |
 */
 // phpcs:enable
-$config['server'] = 'server.hostname.com';
-$config['port'] = '389';
+$config['ldap_connect_uri'] = 'ldap://server.hostname.com:389';
 $config['username'] = 'user@server.hostname.com';
 $config['password'] = 'password';
 $config['dn'] = 'dc=server,dc=hostname,dc=com';

--- a/application/plugins/phonebook_ldap/phonebook_ldap.php
+++ b/application/plugins/phonebook_ldap/phonebook_ldap.php
@@ -69,7 +69,7 @@ function phonebook_ldap($number)
 	$config = Plugin_helper::get_plugin_config('phonebook_ldap');
 
 	// specify the LDAP server to connect to
-	$conn = ldap_connect($config['server'], $config['port']);
+	$conn = ldap_connect($config['ldap_connect_uri']);
 	if ( ! $conn)
 	{
 		return FALSE;


### PR DESCRIPTION
PHP 8.3 has: Deprecate calling 'ldap_connect' with 2 parameters So we have to use the 1 parameter call instead

See: https://wiki.php.net/rfc/deprecations_php_8_3