### PR TITLE
replace rand() & mt_rand() by random_int()

### DIFF
--- a/application/models/gateway/Gammu_model.php
+++ b/application/models/gateway/Gammu_model.php
@@ -144,7 +144,7 @@ class Gammu_model extends MY_Model {
 
 				// generate UDH
 				$UDH = '050003';
-				$hex = dechex(mt_rand(0, 255));
+				$hex = dechex(random_int(0, 255));
 				$hex = str_pad($hex, 2, '0', STR_PAD_LEFT);
 				$UDH .= strtoupper($hex);
 				$data['UDH'] = $UDH;
@@ -1455,7 +1455,7 @@ class Gammu_model extends MY_Model {
 			$newUDH = '';
 			for ($j = 1; $j <= 4; $j++)
 			{
-				$newUDH .= strtoupper(dechex(mt_rand(0, 255)));
+				$newUDH .= strtoupper(dechex(random_int(0, 255)));
 			}
 			$data->UDH = $newUDH.substr($data->UDH, -4);
 		}

--- a/application/models/gateway/Way2sms_model.php
+++ b/application/models/gateway/Way2sms_model.php
@@ -69,7 +69,7 @@ class Way2sms_model extends Gammu_model {
 		$uid = urlencode($uid);
 		$pwd = urlencode($pwd);
 
-		$autobalancer = rand(1, 8);
+		$autobalancer = random_int(1, 8);
 
 		curl_setopt($curl, CURLOPT_URL, 'http://site'.$autobalancer.'.way2sms.com/Login1.action');
 		curl_setopt($curl, CURLOPT_POST, 1);

--- a/application/plugins/sms_to_twitter/libraries/Epi.php
+++ b/application/plugins/sms_to_twitter/libraries/Epi.php
@@ -414,7 +414,7 @@ class EpiOAuth
     if(isset($this->nonce)) // for unit testing
       return $this->nonce;
 
-    return md5(uniqid(rand(), true));
+    return md5(uniqid(random_int(0, PHP_INT_MAX), true));
   }
 
   // parameters should already have been passed through prepareParameters

--- a/application/plugins/sms_to_xmpp/libraries/abhinavsingh-JAXL-5829c3b/core/jaxl.util.php
+++ b/application/plugins/sms_to_xmpp/libraries/abhinavsingh-JAXL-5829c3b/core/jaxl.util.php
@@ -41,6 +41,31 @@
  * @link http://code.google.com/p/jaxl
  */
 
+// Based on: https://3v4l.org/B18he from https://wiki.php.net/rfc/deprecations_php_8_3
+function my_mt_srand($seed = null) {
+    if (version_compare(PHP_VERSION, '8.2.0') >= 0) {
+        $GLOBALS['my_mt_rand'] = new \Random\Randomizer(new \Random\Engine\Mt19937($seed));
+    } else {
+        mt_srand($seed);
+    }
+}
+
+function my_mt_rand($min = null, $max = null) {
+    if (version_compare(PHP_VERSION, '8.2.0') >= 0) {
+        if (!isset($GLOBALS['my_mt_rand'])) {
+            $GLOBALS['my_mt_rand'] = new \Random\Randomizer(new \Random\Engine\Mt19937());
+        }
+
+        if ($min === null && $max === null) {
+            return $GLOBALS['my_mt_rand']->nextInt();
+        }
+
+        return $GLOBALS['my_mt_rand']->getInt($min, $max);
+    } else {
+        return mt_rand($min, $max);
+    }
+}
+
     /**
      * Jaxl Utility Class
     */
@@ -128,9 +153,9 @@
         
         public static function generateNonce() {
             $str = '';
-            mt_srand((double) microtime()*10000000);
+            my_mt_srand((double) microtime()*10000000);
             for($i=0; $i<32; $i++)
-                $str .= chr(mt_rand(0, 255));
+                $str .= chr(my_mt_rand(0, 255));
             return $str;
         }
         

--- a/application/plugins/sms_to_xmpp/libraries/abhinavsingh-JAXL-5829c3b/xep/jaxl.0124.php
+++ b/application/plugins/sms_to_xmpp/libraries/abhinavsingh-JAXL-5829c3b/xep/jaxl.0124.php
@@ -142,7 +142,7 @@
         }
         
         public static function loadSession($jaxl) {
-            $jaxl->bosh['rid'] = isset($_SESSION['jaxl_rid']) ? (string) $_SESSION['jaxl_rid'] : rand(1000, 10000);
+            $jaxl->bosh['rid'] = isset($_SESSION['jaxl_rid']) ? (string) $_SESSION['jaxl_rid'] : random_int(1000, 10000);
             $jaxl->bosh['sid'] = isset($_SESSION['jaxl_sid']) ? (string) $_SESSION['jaxl_sid'] : false;
             $jaxl->lastid = isset($_SESSION['jaxl_id']) ? $_SESSION['jaxl_id'] : $jaxl->lastid;
             $jaxl->jid = isset($_SESSION['jaxl_jid']) ? $_SESSION['jaxl_jid'] : $jaxl->jid;

--- a/application/plugins/sms_to_xmpp/libraries/abhinavsingh-JAXL-5829c3b/xmpp/xmpp.class.php
+++ b/application/plugins/sms_to_xmpp/libraries/abhinavsingh-JAXL-5829c3b/xmpp/xmpp.class.php
@@ -210,7 +210,7 @@
             $this->clocked = $this->startTime = time();
             
             /* Parse configuration parameter */
-            $this->lastid = rand(1, 9);
+            $this->lastid = random_int(1, 9);
             $this->streamTimeout = isset($config['streamTimeout']) ? $config['streamTimeout'] : 20;
             $this->rateLimit = isset($config['rateLimit']) ? $config['rateLimit'] : true;
             $this->getPktSize = isset($config['getPktSize']) ? $config['getPktSize'] : 4096;


### PR DESCRIPTION
These functions will be deprecated in PHP 8.3
https://wiki.php.net/rfc/deprecations_php_8_3

Replace them by random_int() which also has a userland implementation for PHP < 7.0 that we already use in this project (paragonie/random_compat)