### PR TITLE
change kalkun license to GPL-2.0-or-later

### DIFF
--- a/application/controllers/Daemon.php
+++ b/application/controllers/Daemon.php
@@ -5,7 +5,7 @@
  *
  * @package		Kalkun
  * @author		Kalkun Dev Team
- * @license		https://spdx.org/licenses/GPL-3.0-or-later.html
+ * @license		https://spdx.org/licenses/GPL-2.0-or-later.html
  * @link		https://kalkun.sourceforge.io/
  */
 

--- a/application/controllers/Install.php
+++ b/application/controllers/Install.php
@@ -5,7 +5,7 @@
  *
  * @package		Kalkun
  * @author		Kalkun Dev Team
- * @license		https://spdx.org/licenses/GPL-3.0-or-later.html
+ * @license		https://spdx.org/licenses/GPL-2.0-or-later.html
  * @link		https://kalkun.sourceforge.io/
  */
 

--- a/application/controllers/Kalkun.php
+++ b/application/controllers/Kalkun.php
@@ -5,7 +5,7 @@
  *
  * @package		Kalkun
  * @author		Kalkun Dev Team
- * @license		https://spdx.org/licenses/GPL-3.0-or-later.html
+ * @license		https://spdx.org/licenses/GPL-2.0-or-later.html
  * @link		https://kalkun.sourceforge.io/
  */
 

--- a/application/controllers/Login.php
+++ b/application/controllers/Login.php
@@ -5,7 +5,7 @@
  *
  * @package		Kalkun
  * @author		Kalkun Dev Team
- * @license		https://spdx.org/licenses/GPL-3.0-or-later.html
+ * @license		https://spdx.org/licenses/GPL-2.0-or-later.html
  * @link		https://kalkun.sourceforge.io/
  */
 

--- a/application/controllers/Messages.php
+++ b/application/controllers/Messages.php
@@ -5,7 +5,7 @@
  *
  * @package		Kalkun
  * @author		Kalkun Dev Team
- * @license		https://spdx.org/licenses/GPL-3.0-or-later.html
+ * @license		https://spdx.org/licenses/GPL-2.0-or-later.html
  * @link		https://kalkun.sourceforge.io/
  */
 

--- a/application/controllers/Phonebook.php
+++ b/application/controllers/Phonebook.php
@@ -5,7 +5,7 @@
  *
  * @package		Kalkun
  * @author		Kalkun Dev Team
- * @license		https://spdx.org/licenses/GPL-3.0-or-later.html
+ * @license		https://spdx.org/licenses/GPL-2.0-or-later.html
  * @link		https://kalkun.sourceforge.io/
  */
 

--- a/application/controllers/Pluginss.php
+++ b/application/controllers/Pluginss.php
@@ -5,7 +5,7 @@
  *
  * @package		Kalkun
  * @author		Kalkun Dev Team
- * @license		https://spdx.org/licenses/GPL-3.0-or-later.html
+ * @license		https://spdx.org/licenses/GPL-2.0-or-later.html
  * @link		https://kalkun.sourceforge.io/
  */
 

--- a/application/controllers/Users.php
+++ b/application/controllers/Users.php
@@ -5,7 +5,7 @@
  *
  * @package		Kalkun
  * @author		Kalkun Dev Team
- * @license		https://spdx.org/licenses/GPL-3.0-or-later.html
+ * @license		https://spdx.org/licenses/GPL-2.0-or-later.html
  * @link		https://kalkun.sourceforge.io/
  */
 

--- a/application/core/MY_Controller.php
+++ b/application/core/MY_Controller.php
@@ -5,7 +5,7 @@
  *
  * @package		Kalkun
  * @author		Kalkun Dev Team
- * @license		https://spdx.org/licenses/GPL-3.0-or-later.html
+ * @license		https://spdx.org/licenses/GPL-2.0-or-later.html
  * @link		https://kalkun.sourceforge.io/
  */
 

--- a/application/core/MY_Lang.php
+++ b/application/core/MY_Lang.php
@@ -7,7 +7,7 @@ defined('BASEPATH') OR exit('No direct script access allowed');
  *
  * @copyright 2021 Fab Stz
  * @author Fab Stz <fabstz-it@yahoo.fr>
- * @license <https://spdx.org/licenses/GPL-3.0-or-later.html> GPL-3.0-or-later
+ * @license <https://spdx.org/licenses/GPL-2.0-or-later.html> GPL-2.0-or-later
  * @link https://kalkun.sourceforge.io/
  */
 

--- a/application/core/MY_Model.php
+++ b/application/core/MY_Model.php
@@ -7,7 +7,7 @@ defined('BASEPATH') OR exit('No direct script access allowed');
  *
  * @copyright 2021 Fab Stz
  * @author Fab Stz <fabstz-it@yahoo.fr>
- * @license <https://spdx.org/licenses/GPL-3.0-or-later.html> GPL-3.0-or-later
+ * @license <https://spdx.org/licenses/GPL-2.0-or-later.html> GPL-2.0-or-later
  * @link https://kalkun.sourceforge.io/
  */
 

--- a/application/helpers/i18n_helper.php
+++ b/application/helpers/i18n_helper.php
@@ -7,7 +7,7 @@ defined('BASEPATH') OR exit('No direct script access allowed');
  *
  * @copyright 2021 Fab Stz
  * @author Fab Stz <fabstz-it@yahoo.fr>
- * @license <https://spdx.org/licenses/GPL-3.0-or-later.html> GPL-3.0-or-later
+ * @license <https://spdx.org/licenses/GPL-2.0-or-later.html> GPL-2.0-or-later
  * @link https://kalkun.sourceforge.io/
  */
 

--- a/application/helpers/kalkun_helper.php
+++ b/application/helpers/kalkun_helper.php
@@ -8,7 +8,7 @@ defined('BASEPATH') OR exit('No direct script access allowed');
  *
  * @package     Kalkun
  * @author      Kalkun Dev Team
- * @license     <https://spdx.org/licenses/GPL-3.0-or-later.html> GPL-3.0-or-later
+ * @license     <https://spdx.org/licenses/GPL-2.0-or-later.html> GPL-2.0-or-later
  * @link        https://kalkun.sourceforge.io/
  */
 

--- a/application/libraries/MY_Pagination.php
+++ b/application/libraries/MY_Pagination.php
@@ -7,7 +7,7 @@ defined('BASEPATH') OR exit('No direct script access allowed');
  *
  * @copyright 2022 Fab Stz
  * @author Fab Stz <fabstz-it@yahoo.fr>
- * @license <https://spdx.org/licenses/GPL-3.0-or-later.html> GPL-3.0-or-later
+ * @license <https://spdx.org/licenses/GPL-2.0-or-later.html> GPL-2.0-or-later
  * @link https://kalkun.sourceforge.io/
  */
 

--- a/application/models/Kalkun_model.php
+++ b/application/models/Kalkun_model.php
@@ -5,7 +5,7 @@
  *
  * @package		Kalkun
  * @author		Kalkun Dev Team
- * @license		https://spdx.org/licenses/GPL-3.0-or-later.html
+ * @license		https://spdx.org/licenses/GPL-2.0-or-later.html
  * @link		https://kalkun.sourceforge.io/
  */
 

--- a/application/models/Message_model.php
+++ b/application/models/Message_model.php
@@ -5,7 +5,7 @@
  *
  * @package		Kalkun
  * @author		Kalkun Dev Team
- * @license		https://spdx.org/licenses/GPL-3.0-or-later.html
+ * @license		https://spdx.org/licenses/GPL-2.0-or-later.html
  * @link		https://kalkun.sourceforge.io/
  */
 

--- a/application/models/Phonebook_model.php
+++ b/application/models/Phonebook_model.php
@@ -5,7 +5,7 @@
  *
  * @package		Kalkun
  * @author		Kalkun Dev Team
- * @license		https://spdx.org/licenses/GPL-3.0-or-later.html
+ * @license		https://spdx.org/licenses/GPL-2.0-or-later.html
  * @link		https://kalkun.sourceforge.io/
  */
 

--- a/application/models/Plugin_model.php
+++ b/application/models/Plugin_model.php
@@ -5,7 +5,7 @@
  *
  * @package		Kalkun
  * @author		Kalkun Dev Team
- * @license		https://spdx.org/licenses/GPL-3.0-or-later.html
+ * @license		https://spdx.org/licenses/GPL-2.0-or-later.html
  * @link		https://kalkun.sourceforge.io/
  */
 

--- a/application/models/Spam_model.php
+++ b/application/models/Spam_model.php
@@ -5,7 +5,7 @@
  *
  * @package		Kalkun
  * @author		Kalkun Dev Team
- * @license		https://spdx.org/licenses/GPL-3.0-or-later.html
+ * @license		https://spdx.org/licenses/GPL-2.0-or-later.html
  * @link		https://kalkun.sourceforge.io/
  */
 

--- a/application/models/User_model.php
+++ b/application/models/User_model.php
@@ -5,7 +5,7 @@
  *
  * @package		Kalkun
  * @author		Kalkun Dev Team
- * @license		https://spdx.org/licenses/GPL-3.0-or-later.html
+ * @license		https://spdx.org/licenses/GPL-2.0-or-later.html
  * @link		https://kalkun.sourceforge.io/
  */
 

--- a/application/models/gateway/Clickatell_model.php
+++ b/application/models/gateway/Clickatell_model.php
@@ -5,7 +5,7 @@
  *
  * @package		Kalkun
  * @author		Kalkun Dev Team
- * @license		https://spdx.org/licenses/GPL-3.0-or-later.html
+ * @license		https://spdx.org/licenses/GPL-2.0-or-later.html
  * @link		https://kalkun.sourceforge.io/
  */
 

--- a/application/models/gateway/Connekt_model.php
+++ b/application/models/gateway/Connekt_model.php
@@ -5,7 +5,7 @@
  *
  * @package		Kalkun
  * @author		Kalkun Dev Team
- * @license		https://spdx.org/licenses/GPL-3.0-or-later.html
+ * @license		https://spdx.org/licenses/GPL-2.0-or-later.html
  * @link		https://kalkun.sourceforge.io/
  */
 

--- a/application/models/gateway/Gammu_model.php
+++ b/application/models/gateway/Gammu_model.php
@@ -5,7 +5,7 @@
  *
  * @package		Kalkun
  * @author		Kalkun Dev Team
- * @license		https://spdx.org/licenses/GPL-3.0-or-later.html
+ * @license		https://spdx.org/licenses/GPL-2.0-or-later.html
  * @link		https://kalkun.sourceforge.io/
  */
 

--- a/application/models/gateway/Kannel_model.php
+++ b/application/models/gateway/Kannel_model.php
@@ -5,7 +5,7 @@
  *
  * @package		Kalkun
  * @author		Kalkun Dev Team
- * @license		https://spdx.org/licenses/GPL-3.0-or-later.html
+ * @license		https://spdx.org/licenses/GPL-2.0-or-later.html
  * @link		https://kalkun.sourceforge.io/
  */
 

--- a/application/models/gateway/Nongammu_model.php
+++ b/application/models/gateway/Nongammu_model.php
@@ -5,7 +5,7 @@
  *
  * @package		Kalkun
  * @author		Kalkun Dev Team
- * @license		https://spdx.org/licenses/GPL-3.0-or-later.html
+ * @license		https://spdx.org/licenses/GPL-2.0-or-later.html
  * @link		https://kalkun.sourceforge.io/
  */
 

--- a/application/models/gateway/Nowsms_model.php
+++ b/application/models/gateway/Nowsms_model.php
@@ -5,7 +5,7 @@
  *
  * @package		Kalkun
  * @author		Kalkun Dev Team
- * @license		https://spdx.org/licenses/GPL-3.0-or-later.html
+ * @license		https://spdx.org/licenses/GPL-2.0-or-later.html
  * @link		https://kalkun.sourceforge.io/
  */
 

--- a/application/models/gateway/Ozeking_model.php
+++ b/application/models/gateway/Ozeking_model.php
@@ -5,7 +5,7 @@
  *
  * @package		Kalkun
  * @author		Kalkun Dev Team
- * @license		https://spdx.org/licenses/GPL-3.0-or-later.html
+ * @license		https://spdx.org/licenses/GPL-2.0-or-later.html
  * @link		https://kalkun.sourceforge.io/
  */
 

--- a/application/models/gateway/Panacea_model.php
+++ b/application/models/gateway/Panacea_model.php
@@ -5,7 +5,7 @@
  *
  * @package		Kalkun
  * @author		joseph mazigo
- * @license		https://spdx.org/licenses/GPL-3.0-or-later.html
+ * @license		https://spdx.org/licenses/GPL-2.0-or-later.html
  * @link		https://kalkun.sourceforge.io/
  * @link        http://josephmazigo.com
  */

--- a/application/models/gateway/Tmobilecz_model.php
+++ b/application/models/gateway/Tmobilecz_model.php
@@ -5,7 +5,7 @@
  *
  * @package		Kalkun
  * @author		Kalkun Dev Team
- * @license		https://spdx.org/licenses/GPL-3.0-or-later.html
+ * @license		https://spdx.org/licenses/GPL-2.0-or-later.html
  * @link		https://kalkun.sourceforge.io/
  */
 

--- a/application/models/gateway/Way2sms_model.php
+++ b/application/models/gateway/Way2sms_model.php
@@ -5,7 +5,7 @@
  *
  * @package		Kalkun
  * @author		Kalkun Dev Team
- * @license		https://spdx.org/licenses/GPL-3.0-or-later.html
+ * @license		https://spdx.org/licenses/GPL-2.0-or-later.html
  * @link		https://kalkun.sourceforge.io/
  */
 

--- a/application/plugins/Plugin_controller.php
+++ b/application/plugins/Plugin_controller.php
@@ -5,7 +5,7 @@
  *
  * @package		Kalkun
  * @author		Kalkun Dev Team
- * @license		https://spdx.org/licenses/GPL-3.0-or-later.html
+ * @license		https://spdx.org/licenses/GPL-2.0-or-later.html
  * @link		https://kalkun.sourceforge.io/
  */
 

--- a/application/plugins/Plugin_helper.php
+++ b/application/plugins/Plugin_helper.php
@@ -7,7 +7,7 @@ defined('BASEPATH') OR exit('No direct script access allowed');
  *
  * @copyright 2021 Kalkun Dev Team
  * @author Kalkun Dev Team
- * @license <https://spdx.org/licenses/GPL-3.0-or-later.html> GPL-3.0-or-later
+ * @license <https://spdx.org/licenses/GPL-2.0-or-later.html> GPL-2.0-or-later
  * @link https://kalkun.sourceforge.io/
  */
 

--- a/application/plugins/blacklist_number/controllers/Blacklist_number.php
+++ b/application/plugins/blacklist_number/controllers/Blacklist_number.php
@@ -5,7 +5,7 @@
  *
  * @package		Kalkun
  * @author		Kalkun Dev Team
- * @license		https://spdx.org/licenses/GPL-3.0-or-later.html
+ * @license		https://spdx.org/licenses/GPL-2.0-or-later.html
  * @link		https://kalkun.sourceforge.io/
  */
 

--- a/application/plugins/blacklist_number/models/Blacklist_number_model.php
+++ b/application/plugins/blacklist_number/models/Blacklist_number_model.php
@@ -5,7 +5,7 @@
  *
  * @package		Kalkun
  * @author		Kalkun Dev Team
- * @license		https://spdx.org/licenses/GPL-3.0-or-later.html
+ * @license		https://spdx.org/licenses/GPL-2.0-or-later.html
  * @link		https://kalkun.sourceforge.io/
  */
 

--- a/application/plugins/jsonrpc/controllers/Jsonrpc.php
+++ b/application/plugins/jsonrpc/controllers/Jsonrpc.php
@@ -5,7 +5,7 @@
  *
  * @package		Kalkun
  * @author		Kalkun Dev Team
- * @license		https://spdx.org/licenses/GPL-3.0-or-later.html
+ * @license		https://spdx.org/licenses/GPL-2.0-or-later.html
  * @link		https://kalkun.sourceforge.io/
  */
 

--- a/application/plugins/jsonrpc/libraries/Evaluator.php
+++ b/application/plugins/jsonrpc/libraries/Evaluator.php
@@ -5,7 +5,7 @@
  *
  * @package		Kalkun
  * @author		Kalkun Dev Team
- * @license		https://spdx.org/licenses/GPL-3.0-or-later.html
+ * @license		https://spdx.org/licenses/GPL-2.0-or-later.html
  * @link		https://kalkun.sourceforge.io/
  */
 

--- a/application/plugins/rest_api/controllers/Rest_api.php
+++ b/application/plugins/rest_api/controllers/Rest_api.php
@@ -5,7 +5,7 @@
  *
  * @package		Kalkun
  * @author		Kalkun Dev Team
- * @license		https://spdx.org/licenses/GPL-3.0-or-later.html
+ * @license		https://spdx.org/licenses/GPL-2.0-or-later.html
  * @link		https://kalkun.sourceforge.io/
  */
 

--- a/application/plugins/server_alert/controllers/Server_alert.php
+++ b/application/plugins/server_alert/controllers/Server_alert.php
@@ -5,7 +5,7 @@
  *
  * @package		Kalkun
  * @author		Kalkun Dev Team
- * @license		https://spdx.org/licenses/GPL-3.0-or-later.html
+ * @license		https://spdx.org/licenses/GPL-2.0-or-later.html
  * @link		https://kalkun.sourceforge.io/
  */
 

--- a/application/plugins/server_alert/models/Server_alert_model.php
+++ b/application/plugins/server_alert/models/Server_alert_model.php
@@ -5,7 +5,7 @@
  *
  * @package		Kalkun
  * @author		Kalkun Dev Team
- * @license		https://spdx.org/licenses/GPL-3.0-or-later.html
+ * @license		https://spdx.org/licenses/GPL-2.0-or-later.html
  * @link		https://kalkun.sourceforge.io/
  */
 

--- a/application/plugins/sms_credit/controllers/Sms_credit.php
+++ b/application/plugins/sms_credit/controllers/Sms_credit.php
@@ -5,7 +5,7 @@
  *
  * @package     Kalkun
  * @author      Kalkun Dev Team
- * @license     https://spdx.org/licenses/GPL-3.0-or-later.html
+ * @license     https://spdx.org/licenses/GPL-2.0-or-later.html
  * @link        https://kalkun.sourceforge.io/
  */
 

--- a/application/plugins/sms_credit/models/Sms_credit_model.php
+++ b/application/plugins/sms_credit/models/Sms_credit_model.php
@@ -5,7 +5,7 @@
  *
  * @package     Kalkun
  * @author      Kalkun Dev Team
- * @license     https://spdx.org/licenses/GPL-3.0-or-later.html
+ * @license     https://spdx.org/licenses/GPL-2.0-or-later.html
  * @link        https://kalkun.sourceforge.io/
  */
 

--- a/application/plugins/sms_member/controllers/Sms_member.php
+++ b/application/plugins/sms_member/controllers/Sms_member.php
@@ -5,7 +5,7 @@
  *
  * @package		Kalkun
  * @author		Kalkun Dev Team
- * @license		https://spdx.org/licenses/GPL-3.0-or-later.html
+ * @license		https://spdx.org/licenses/GPL-2.0-or-later.html
  * @link		https://kalkun.sourceforge.io/
  */
 

--- a/application/plugins/sms_member/models/Sms_member_model.php
+++ b/application/plugins/sms_member/models/Sms_member_model.php
@@ -5,7 +5,7 @@
  *
  * @package		Kalkun
  * @author		Kalkun Dev Team
- * @license		https://spdx.org/licenses/GPL-3.0-or-later.html
+ * @license		https://spdx.org/licenses/GPL-2.0-or-later.html
  * @link		https://kalkun.sourceforge.io/
  */
 

--- a/application/plugins/sms_to_email/controllers/Sms_to_email.php
+++ b/application/plugins/sms_to_email/controllers/Sms_to_email.php
@@ -5,7 +5,7 @@
  *
  * @package		Kalkun
  * @author		Kalkun Dev Team
- * @license		https://spdx.org/licenses/GPL-3.0-or-later.html
+ * @license		https://spdx.org/licenses/GPL-2.0-or-later.html
  * @link		https://kalkun.sourceforge.io/
  */
 

--- a/application/plugins/sms_to_email/models/Sms_to_email_model.php
+++ b/application/plugins/sms_to_email/models/Sms_to_email_model.php
@@ -5,7 +5,7 @@
  *
  * @package		Kalkun
  * @author		Kalkun Dev Team
- * @license		https://spdx.org/licenses/GPL-3.0-or-later.html
+ * @license		https://spdx.org/licenses/GPL-2.0-or-later.html
  * @link		https://kalkun.sourceforge.io/
  */
 

--- a/application/plugins/sms_to_twitter/controllers/Sms_to_twitter.php
+++ b/application/plugins/sms_to_twitter/controllers/Sms_to_twitter.php
@@ -5,7 +5,7 @@
  *
  * @package		Kalkun
  * @author		Kalkun Dev Team
- * @license		https://spdx.org/licenses/GPL-3.0-or-later.html
+ * @license		https://spdx.org/licenses/GPL-2.0-or-later.html
  * @link		https://kalkun.sourceforge.io/
  */
 

--- a/application/plugins/sms_to_twitter/models/Sms_to_twitter_model.php
+++ b/application/plugins/sms_to_twitter/models/Sms_to_twitter_model.php
@@ -5,7 +5,7 @@
  *
  * @package		Kalkun
  * @author		Kalkun Dev Team
- * @license		https://spdx.org/licenses/GPL-3.0-or-later.html
+ * @license		https://spdx.org/licenses/GPL-2.0-or-later.html
  * @link		https://kalkun.sourceforge.io/
  */
 

--- a/application/plugins/sms_to_wordpress/controllers/Sms_to_wordpress.php
+++ b/application/plugins/sms_to_wordpress/controllers/Sms_to_wordpress.php
@@ -5,7 +5,7 @@
  *
  * @package		Kalkun
  * @author		Kalkun Dev Team
- * @license		https://spdx.org/licenses/GPL-3.0-or-later.html
+ * @license		https://spdx.org/licenses/GPL-2.0-or-later.html
  * @link		https://kalkun.sourceforge.io/
  */
 

--- a/application/plugins/sms_to_wordpress/models/Sms_to_wordpress_model.php
+++ b/application/plugins/sms_to_wordpress/models/Sms_to_wordpress_model.php
@@ -5,7 +5,7 @@
  *
  * @package		Kalkun
  * @author		Kalkun Dev Team
- * @license		https://spdx.org/licenses/GPL-3.0-or-later.html
+ * @license		https://spdx.org/licenses/GPL-2.0-or-later.html
  * @link		https://kalkun.sourceforge.io/
  */
 

--- a/application/plugins/sms_to_xmpp/controllers/Sms_to_xmpp.php
+++ b/application/plugins/sms_to_xmpp/controllers/Sms_to_xmpp.php
@@ -5,7 +5,7 @@
  *
  * @package		Kalkun
  * @author		Kalkun Dev Team
- * @license		https://spdx.org/licenses/GPL-3.0-or-later.html
+ * @license		https://spdx.org/licenses/GPL-2.0-or-later.html
  * @link		https://kalkun.sourceforge.io/
  */
 

--- a/application/plugins/sms_to_xmpp/models/Sms_to_xmpp_model.php
+++ b/application/plugins/sms_to_xmpp/models/Sms_to_xmpp_model.php
@@ -5,7 +5,7 @@
  *
  * @package		Kalkun
  * @author		Kalkun Dev Team
- * @license		https://spdx.org/licenses/GPL-3.0-or-later.html
+ * @license		https://spdx.org/licenses/GPL-2.0-or-later.html
  * @link		https://kalkun.sourceforge.io/
  */
 

--- a/application/plugins/soap/controllers/Soap.php
+++ b/application/plugins/soap/controllers/Soap.php
@@ -5,7 +5,7 @@
  *
  * @package		Kalkun
  * @author		Kalkun Dev Team
- * @license		https://spdx.org/licenses/GPL-3.0-or-later.html
+ * @license		https://spdx.org/licenses/GPL-2.0-or-later.html
  * @link		https://kalkun.sourceforge.io/
  */
 

--- a/application/plugins/stop_manager/controllers/Stop_manager.php
+++ b/application/plugins/stop_manager/controllers/Stop_manager.php
@@ -5,7 +5,7 @@
  *
  * @package     Kalkun
  * @author      Kalkun Dev Team
- * @license     https://spdx.org/licenses/GPL-3.0-or-later.html
+ * @license     https://spdx.org/licenses/GPL-2.0-or-later.html
  * @link        https://kalkun.sourceforge.io/
  */
 

--- a/application/plugins/stop_manager/libraries/Config.php
+++ b/application/plugins/stop_manager/libraries/Config.php
@@ -6,7 +6,7 @@
  *
  * @package		Kalkun
  * @author		Kalkun Dev Team
- * @license		https://spdx.org/licenses/GPL-3.0-or-later.html
+ * @license		https://spdx.org/licenses/GPL-2.0-or-later.html
  * @link		https://kalkun.sourceforge.io/
  */
 // ------------------------------------------------------------------------

--- a/application/plugins/stop_manager/libraries/MsgIncoming.php
+++ b/application/plugins/stop_manager/libraries/MsgIncoming.php
@@ -6,7 +6,7 @@
  *
  * @package		Kalkun
  * @author		Kalkun Dev Team
- * @license		https://spdx.org/licenses/GPL-3.0-or-later.html
+ * @license		https://spdx.org/licenses/GPL-2.0-or-later.html
  * @link		https://kalkun.sourceforge.io/
  */
 // ------------------------------------------------------------------------

--- a/application/plugins/stop_manager/libraries/MsgOutgoing.php
+++ b/application/plugins/stop_manager/libraries/MsgOutgoing.php
@@ -6,7 +6,7 @@
  *
  * @package		Kalkun
  * @author		Kalkun Dev Team
- * @license		https://spdx.org/licenses/GPL-3.0-or-later.html
+ * @license		https://spdx.org/licenses/GPL-2.0-or-later.html
  * @link		https://kalkun.sourceforge.io/
  */
 // ------------------------------------------------------------------------

--- a/application/plugins/stop_manager/models/Stop_manager_model.php
+++ b/application/plugins/stop_manager/models/Stop_manager_model.php
@@ -5,7 +5,7 @@
  *
  * @package Kalkun
  * @author  Kalkun Dev Team
- * @license https://spdx.org/licenses/GPL-3.0-or-later.html
+ * @license https://spdx.org/licenses/GPL-2.0-or-later.html
  * @link    https://kalkun.sourceforge.io/
  */
 

--- a/application/plugins/whitelist_number/controllers/Whitelist_number.php
+++ b/application/plugins/whitelist_number/controllers/Whitelist_number.php
@@ -5,7 +5,7 @@
  *
  * @package		Kalkun
  * @author		Kalkun Dev Team
- * @license		https://spdx.org/licenses/GPL-3.0-or-later.html
+ * @license		https://spdx.org/licenses/GPL-2.0-or-later.html
  * @link		https://kalkun.sourceforge.io/
  */
 

--- a/application/plugins/whitelist_number/models/Whitelist_number_model.php
+++ b/application/plugins/whitelist_number/models/Whitelist_number_model.php
@@ -5,7 +5,7 @@
  *
  * @package		Kalkun
  * @author		Kalkun Dev Team
- * @license		https://spdx.org/licenses/GPL-3.0-or-later.html
+ * @license		https://spdx.org/licenses/GPL-2.0-or-later.html
  * @link		https://kalkun.sourceforge.io/
  */
 

--- a/application/plugins/xmlrpc/controllers/Xmlrpc.php
+++ b/application/plugins/xmlrpc/controllers/Xmlrpc.php
@@ -5,7 +5,7 @@
  *
  * @package		Kalkun
  * @author		Kalkun Dev Team
- * @license		https://spdx.org/licenses/GPL-3.0-or-later.html
+ * @license		https://spdx.org/licenses/GPL-2.0-or-later.html
  * @link		https://kalkun.sourceforge.io/
  */
 

--- a/application/views/main/base.php
+++ b/application/views/main/base.php
@@ -27,7 +27,7 @@
 			<tr>
 				<td><b><?php echo tr('License'); ?>:</b></td>
 				<td>&nbsp;</td>
-				<td><a class="base_color underline_link" href="https://spdx.org/licenses/GPL-3.0-or-later.html">GPL-3.0-or-later</a></td>
+				<td><a class="base_color underline_link" href="https://spdx.org/licenses/GPL-2.0-or-later.html">GPL-2.0-or-later</a></td>
 			<tr>
 				<td><b><?php echo tr('Homepage'); ?>:</b></td>
 				<td>&nbsp;</td>

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "kalkun-sms/kalkun",
     "description": "Kalkun SMS Manager",
     "type": "project",
-    "license": "GPL-3.0-or-later",
+    "license": "GPL-2.0-or-later",
     "require": {
         "php": ">=5.6",
         "ext-ctype": "*",

--- a/docs/README.md
+++ b/docs/README.md
@@ -72,4 +72,4 @@ Please check the wiki [contribution suggestions](https://github.com/kalkun-sms/K
 See the [documentation on the Wiki](https://github.com/kalkun-sms/Kalkun/wiki)
 
 ### License
-Kalkun is licensed under GPL-3-or-later.
+Kalkun is licensed under [GPL-2.0-or-later](https://spdx.org/licenses/GPL-2.0-or-later.html).

--- a/utils/check_translation.php
+++ b/utils/check_translation.php
@@ -5,7 +5,7 @@ if (php_sapi_name() !== 'cli') exit;
 /**
  * This is part of kalkun - a web based SMS manager
  * Copyright: 2021 Fab Stz <fabstz-it@yahoo.fr>
- * License: GPL-3-or-later
+ * License: GPL-2.0-or-later
  *
  * This script will recursively check the PHP files in a directory for
  * translation inconsistencies


### PR DESCRIPTION
Currently kalkun is licensed under `GPL-3-or-later`. However, kalkun is closely bound to Gammu which is `GPL-2-only`. Moreover, some of the code/files in kalkun is also under GPL2 license.

For example:
application/plugins/sms_to_twitter/libraries/Epi.php application/plugins/sms_to_twitter/libraries/Twitter.php application/sql/mysql/pbk_gammu.sql
application/sql/pgsql/pbk_gammu.sql
application/sql/sqlite/pbk_gammu.sql

The problem is that these licenses (`GPL-3-or-later` & `GPL-2-only`) are actually not compatible as per https://www.gnu.org/licenses/gpl-faq.en.html#AllCompatibility

Closes: #505