### PR TITLE
Run test from php 5.4 to 8.3, and fix issues with php8.2 of dependencies

### DIFF
--- a/.github/workflows/codeigniter.yml
+++ b/.github/workflows/codeigniter.yml
@@ -99,6 +99,43 @@ jobs:
           args: -O gammu.sql https://raw.githubusercontent.com/gammu/gammu/master/docs/sql/mysql.sql
       - name: Import Gammu DB Schema
         run: mysql -h"127.0.0.1" -P"3306" -uroot -ppassword kalkun < gammu.sql
+      - name: Install/Update ci-phpunit-test
+        run: |
+          php vendor/kenjis/ci-phpunit-test/install.php --from-composer
+          # Workaround a bug in phpunit < 7 where the absence of application/tests/_ci_phpunit_test/ makes it fail
+          # with strpos(): Empty needle in vendor/phpunit/php-file-iterator/src/Iterator.php
+          if ! vendor/bin/phpunit --atleast-version 7; then
+            mkdir -vp application/tests/_ci_phpunit_test
+            # Below the alternative is to remove the culprit line from phpunit.xml
+            #sed -i -e "/<exclude>.\/_ci_phpunit_test\/<\/exclude>/ d" application/tests/phpunit.xml
+          fi
+
+          # Uncomment the monkey patcher function. This will search the line matching "Enabling Monkey Patching"
+          # then search the next "/*", delete that line, search the next "*/" and delete the line, write, and quit.
+          ed -s application/tests/Bootstrap.php <<EOF
+          /Enabling Monkey Patching/
+          /^\/\*$/
+          n
+          d
+          /^\*\/$/
+          n
+          d
+          w
+          q
+          EOF
+
+          rm application/tests/controllers/Welcome_test.php
+
+          # exlude the full application/view dir from coverage, otherwise coverage would fail.
+          # See: https://github.com/kenjis/ci-phpunit-test/issues/412
+          sed -i -e 's|<directory suffix=".php">../views/errors</directory>|<directory suffix=".php">../views</directory>|' application/tests/phpunit.xml
+
+          # the void return type of setUp() methods in phpunit (required since phpunit8) isn't supported
+          # with phpunit <= 6. For these, we remove the ": void" part of the tests
+          if [ $(composer show phpunit/phpunit | grep "^versions : " | rev | cut -d " " -f 1 | rev | cut -d . -f 1) -le 6 ]; then
+            sed -i "/public function setUp()/ s/ : void$//" application/tests/controllers/Install_test.php
+          fi
+
       - name: Test with phpunit
         run: vendor/bin/phpunit --coverage-text -c application/tests
   check-code:

--- a/.github/workflows/codeigniter.yml
+++ b/.github/workflows/codeigniter.yml
@@ -89,8 +89,8 @@ jobs:
           restore-keys: ${{ runner.os }}-composer-
       - name: Install dependencies
         run: |
-          composer update
-          composer install --no-progress --prefer-dist --optimize-autoloader
+          composer update --working-dir=utils
+          composer install --working-dir=utils --no-progress --prefer-dist --optimize-autoloader
           sudo apt-get update
           # html-beautify from the debian package doesn't work for some reason
           #   sudo apt-get install -y node-js-beautify
@@ -101,14 +101,14 @@ jobs:
       - id: check_strict_comparison
         name: Check that strict comparison operators are used everywhere
         run: |
-          git checkout composer.lock
+          #git checkout utils/composer.lock
           git status
           utils/fix_code_style.sh strict
       - id: check_style
         name: Check that code follows Guidelines
         if: always()
         run: |
-          git checkout composer.lock
+          #git checkout utils/composer.lock
           git status
           utils/fix_code_style.sh git-diff
       - name: Archive artifacts

--- a/.github/workflows/codeigniter.yml
+++ b/.github/workflows/codeigniter.yml
@@ -10,11 +10,51 @@ on:
   pull_request:
     branches: [ master, devel ]
 jobs:
+  required_php_versions:
+    name: Get PHP versions to test
+    runs-on: ubuntu-latest
+    outputs:
+      php_versions: ${{ steps.php_ver_step.outputs.PHP_VERSIONS }}
+      php_versions_matrix: ${{ steps.php_ver_step.outputs.PHP_VERSIONS_matrix }}
+    steps:
+      - name: Install required packages
+        run: |
+          if ! command -v jq; then sudo apt-get update && sudo apt-get install -y jq; fi
+      - name: Build PHP_VERSIONS array & PHP_VERSIONS_matrix
+        id: php_ver_step
+        run: |
+          set -x
+
+          # Set array that will store the PHP versions for which we create a package.
+          PHP_VERSIONS=()
+
+          # Get all released php versions above 5.6 (in the format X.Y)
+          for upstream_ver in $(curl https://www.php.net/releases/?json | jq -r '.[].version' | cut -f -2 -d .); do
+            major=$(cut -f 1 -d . <<< "$upstream_ver")
+            for minor in {0..20}; do
+              if dpkg --compare-versions ${major}.$minor le $upstream_ver &&  dpkg --compare-versions ${major}.$minor ge 5.6; then
+                PHP_VERSIONS+=("${major}.$minor")
+              fi
+            done
+          done
+
+          PHP_VERSIONS_matrix=$(sed 's/\ /", "/g' <<<  [\"${PHP_VERSIONS[*]}\"])
+
+          echo "PHP_VERSIONS=${PHP_VERSIONS[*]}" >> "$GITHUB_OUTPUT"
+          echo "PHP_VERSIONS_matrix=$PHP_VERSIONS_matrix" >> "$GITHUB_OUTPUT"
+
+          echo "PHP_VERSIONS=${PHP_VERSIONS[*]}"
+          echo "PHP_VERSIONS_matrix=$PHP_VERSIONS_matrix"
+
   test:
+    continue-on-error: false
+    needs: [ required_php_versions ]
     strategy:
+      fail-fast: false
       matrix:
         operating-system: [ubuntu-latest]
-        php-versions: ['7.2']
+        #php-versions: ['5.6', '7.0', '7.1', '7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3']
+        php-versions: ${{fromJson(needs.required_php_versions.outputs.php_versions_matrix)}}
     runs-on: ${{ matrix.operating-system }}
     steps:
       - name: Checkout

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@ application/config/database.php
 /dist
 
 /utils/launchpad/dput.cf
+
+/utils/composer.lock
+/utils/vendor/

--- a/application/tests/Bootstrap.php
+++ b/application/tests/Bootstrap.php
@@ -359,9 +359,9 @@ MonkeyPatchManager::init([
 	// All patchers you use.
 	'patcher_list' => [
 		'ExitPatcher',
-		// 'FunctionPatcher',
-		// 'MethodPatcher',
-		// 'ConstantPatcher',
+		'FunctionPatcher',
+		'MethodPatcher',
+		'ConstantPatcher',
 	],
 	// Additional functions to patch
 	'functions_to_patch' => [

--- a/application/tests/controllers/Install_test.php
+++ b/application/tests/controllers/Install_test.php
@@ -10,10 +10,21 @@
 
 class Install_test extends TestCase
 {
+	private $realAssertStringContainsString;
+
+	public function setUp() : void
+	{
+		// Using assertContains() with string haystacks is deprecated and will not be supported in PHPUnit 9
+		// Refactor your test to use assertStringContainsString() or assertStringContainsStringIgnoringCase() instead.
+		$this->realAssertStringContainsString = method_exists($this, 'assertStringContainsString')
+			? 'assertStringContainsString'
+			: 'assertContains';
+	}
+
 	public function test_index()
 	{
 		$output = $this->request('GET', 'install');
-		$this->assertContains('<title>Kalkun &rsaquo; Installation</title>', $output);
+		call_user_func_array(array($this, $this->realAssertStringContainsString), array('<title>Kalkun &rsaquo; Installation</title>', $output));
 	}
 
 	public function test_method_404()

--- a/application/third_party/MX/Controller.php
+++ b/application/third_party/MX/Controller.php
@@ -39,6 +39,7 @@ require dirname(__FILE__).'/Base.php';
 class MX_Controller 
 {
 	public $autoload = array();
+	private $load;
 	
 	public function __construct() 
 	{

--- a/application/third_party/MX/Controller.php
+++ b/application/third_party/MX/Controller.php
@@ -42,7 +42,7 @@ class MX_Controller
 	
 	public function __construct() 
 	{
-		$class = str_replace(CI::$APP->config->item('controller_suffix'), '', get_class($this));
+		$class = str_replace(strval(CI::$APP->config->item('controller_suffix')), '', get_class($this));
 		log_message('debug', $class." MX_Controller Initialized");
 		Modules::$registry[strtolower($class)] = $this;	
 		

--- a/application/third_party/MX/Loader.php
+++ b/application/third_party/MX/Loader.php
@@ -37,6 +37,7 @@ defined('BASEPATH') OR exit('No direct script access allowed');
 class MX_Loader extends CI_Loader
 {
 	protected $_module;
+	private $controller;
 	
 	public $_ci_plugins = array();
 	public $_ci_cached_vars = array();

--- a/composer.json
+++ b/composer.json
@@ -22,10 +22,7 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^7",
-        "kenjis/ci-phpunit-test": "^0.17.3",
-        "squizlabs/php_codesniffer": "^3.6",
-        "friendsofphp/php-cs-fixer": "^3.3",
-        "ise/php-codingstandards-codeigniter": "^1.0"
+        "kenjis/ci-phpunit-test": "^0.17.3"
     },
     "suggest": {
         "ext-ldap": "For phonebook_ldap plugin",

--- a/composer.json
+++ b/composer.json
@@ -21,8 +21,8 @@
         "econea/nusoap": "^0.9.5.1"
     },
     "require-dev": {
-        "phpunit/phpunit": "^7",
-        "kenjis/ci-phpunit-test": "^0.17.3"
+        "phpunit/phpunit": ">=4",
+        "kenjis/ci-phpunit-test": ">=1"
     },
     "suggest": {
         "ext-ldap": "For phonebook_ldap plugin",

--- a/composer.json
+++ b/composer.json
@@ -18,6 +18,7 @@
         "league/csv": "^8.2 || ^9.5",
         "datto/json-rpc-http": "^4.0 || ^5.0",
         "kissifrot/php-ixr": "1.8.*",
+        "vaimo/composer-patches": "4.22.4 || ^5",
         "econea/nusoap": "^0.9.5.1"
     },
     "require-dev": {
@@ -29,5 +30,37 @@
         "ext-mysqli": "To connect to a MySQL database",
         "ext-pgsql": "To connect to a PostgreSQL database",
         "ext-sqlite3": "To connect to a SQLite3 database"
+    },
+    "extra": {
+        "patches-base": "patches/{{VendorName}}_{{ModuleName}}/{{version}}/{{file}}",
+        "patches": {
+            "codeigniter/framework": {
+                "Add support for PHP 8.2 (part1)": {
+                    "source": "10-php82_support.patch",
+                    "version": [
+                        "=v3.1.13"
+                        ]
+                },
+                "Add support for PHP 8.2 (part2)": {
+                    "source": "10-php82_support-part2.patch",
+                    "version": [
+                        "=v3.1.13"
+                        ]
+                }
+            },
+            "kenjis/ci-phpunit-test": {
+                "Add support for PHP 8.2": {
+                    "source": "support_php-8.2.patch",
+                    "version": [
+                        "=v3.0.4"
+                        ]
+                }
+            }
+        }
+    },
+    "config": {
+        "allow-plugins": {
+            "vaimo/composer-patches": true
+        }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -12,13 +12,13 @@
         "ext-json": "*",
         "ext-mbstring": "*",
         "ext-session": "*",
-        "codeigniter/framework": ">=3.1.13 <3.2",
+        "codeigniter/framework": "=3.1.13",
         "paragonie/random_compat": ">=2",
         "giggsey/libphonenumber-for-php": "^8.12",
         "league/csv": "^8.2 || ^9.5",
         "datto/json-rpc-http": "^4.0 || ^5.0",
         "kissifrot/php-ixr": "1.8.*",
-        "vaimo/composer-patches": "4.22.4 || ^5",
+        "cweagans/composer-patches": "~1.0",
         "econea/nusoap": "^0.9.5.1"
     },
     "require-dev": {
@@ -32,35 +32,19 @@
         "ext-sqlite3": "To connect to a SQLite3 database"
     },
     "extra": {
-        "patches-base": "patches/{{VendorName}}_{{ModuleName}}/{{version}}/{{file}}",
         "patches": {
             "codeigniter/framework": {
-                "Add support for PHP 8.2 (part1)": {
-                    "source": "10-php82_support.patch",
-                    "version": [
-                        "=v3.1.13"
-                        ]
-                },
-                "Add support for PHP 8.2 (part2)": {
-                    "source": "10-php82_support-part2.patch",
-                    "version": [
-                        "=v3.1.13"
-                        ]
-                }
+                "Add support for PHP 8.2 (part1)": "patches/Codeigniter_Framework/v3.1.13/10-php82_support.patch",
+                "Add support for PHP 8.2 (part2)": "patches/Codeigniter_Framework/v3.1.13/10-php82_support-part2.patch"
             },
             "kenjis/ci-phpunit-test": {
-                "Add support for PHP 8.2": {
-                    "source": "support_php-8.2.patch",
-                    "version": [
-                        "=v3.0.4"
-                        ]
-                }
+                "Add support for PHP 8.2": "patches/Kenjis_CiPhpunitTest/v3.0.4/support_php-8.2.patch"
             }
         }
     },
     "config": {
         "allow-plugins": {
-            "vaimo/composer-patches": true
+            "cweagans/composer-patches": true
         }
     }
 }

--- a/patches/Codeigniter_Framework/v3.1.13/10-php82_support-part2.patch
+++ b/patches/Codeigniter_Framework/v3.1.13/10-php82_support-part2.patch
@@ -1,0 +1,20 @@
+From 2fc2d480d0d3fc778a46ded0e093fef7a0d84257 Mon Sep 17 00:00:00 2001
+From: George Petculescu <gxgpet@gmail.com>
+Date: Fri, 3 Nov 2023 11:59:40 +0200
+Subject: [PATCH] Fixes the usage of `_create_table_if` in Postgres forge class
+
+---
+ system/database/drivers/postgre/postgre_forge.php | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+--- a/system/database/drivers/postgre/postgre_forge.php
++++ b/system/database/drivers/postgre/postgre_forge.php
+@@ -87,7 +87,7 @@
+ 
+ 		if (version_compare($this->db->version(), '9.0', '>'))
+ 		{
+-			$this->create_table_if = 'CREATE TABLE IF NOT EXISTS';
++			$this->_create_table_if = 'CREATE TABLE IF NOT EXISTS';
+ 		}
+ 	}
+ 

--- a/patches/Codeigniter_Framework/v3.1.13/10-php82_support.patch
+++ b/patches/Codeigniter_Framework/v3.1.13/10-php82_support.patch
@@ -1,0 +1,123 @@
+From fb1256a5b009b6264fbc85be44e0d97654d3fcd9 Mon Sep 17 00:00:00 2001
+From: George Petculescu <gxgpet@gmail.com>
+Date: Sun, 6 Nov 2022 16:13:43 +0200
+Subject: [PATCH] Adding PHP 8.2 support
+
+---
+ .github/workflows/test-phpunit.yml          | 20 +++++++++++++++++++-
+ system/core/Loader.php                      |  1 +
+ system/core/URI.php                         |  7 +++++++
+ system/database/DB_driver.php               |  1 +
+ system/libraries/Driver.php                 |  1 +
+ system/libraries/Table.php                  |  4 ++--
+ tests/codeigniter/core/Loader_test.php      |  2 +-
+ tests/codeigniter/libraries/Upload_test.php |  7 ++++---
+ tests/mocks/ci_testcase.php                 |  1 +
+ 9 files changed, 37 insertions(+), 7 deletions(-)
+
+--- a/system/core/Loader.php
++++ b/system/core/Loader.php
+@@ -49,6 +49,7 @@
+  * @author		EllisLab Dev Team
+  * @link		https://codeigniter.com/userguide3/libraries/loader.html
+  */
++#[AllowDynamicProperties]
+ class CI_Loader {
+ 
+ 	// All these are set automatically. Don't mess with them.
+--- a/system/core/URI.php
++++ b/system/core/URI.php
+@@ -52,6 +52,13 @@
+ class CI_URI {
+ 
+ 	/**
++	 * CI_Config instance
++	 *
++	 * @var	CI_Config
++	 */
++	public $config;
++
++	/**
+ 	 * List of cached URI segments
+ 	 *
+ 	 * @var	array
+--- a/system/database/DB_driver.php
++++ b/system/database/DB_driver.php
+@@ -51,6 +51,7 @@
+  * @author		EllisLab Dev Team
+  * @link		https://codeigniter.com/userguide3/database/
+  */
++#[AllowDynamicProperties]
+ abstract class CI_DB_driver {
+ 
+ 	/**
+--- a/system/libraries/Driver.php
++++ b/system/libraries/Driver.php
+@@ -50,6 +50,7 @@
+  * @author		EllisLab Dev Team
+  * @link
+  */
++#[AllowDynamicProperties]
+ class CI_Driver_Library {
+ 
+ 	/**
+--- a/system/libraries/Table.php
++++ b/system/libraries/Table.php
+@@ -489,12 +489,12 @@
+ 			return;
+ 		}
+ 
+-		$this->temp = $this->_default_template();
++		$temp = $this->_default_template();
+ 		foreach (array('table_open', 'thead_open', 'thead_close', 'heading_row_start', 'heading_row_end', 'heading_cell_start', 'heading_cell_end', 'tbody_open', 'tbody_close', 'row_start', 'row_end', 'cell_start', 'cell_end', 'row_alt_start', 'row_alt_end', 'cell_alt_start', 'cell_alt_end', 'table_close') as $val)
+ 		{
+ 			if ( ! isset($this->template[$val]))
+ 			{
+-				$this->template[$val] = $this->temp[$val];
++				$this->template[$val] = $temp[$val];
+ 			}
+ 		}
+ 	}
+--- a/system/core/Controller.php
++++ b/system/core/Controller.php
+@@ -50,6 +50,7 @@
+  * @author		EllisLab Dev Team
+  * @link		https://codeigniter.com/userguide3/general/controllers.html
+  */
++#[AllowDynamicProperties]
+ class CI_Controller {
+ 
+ 	/**
+--- a/system/core/Router.php
++++ b/system/core/Router.php
+@@ -59,6 +59,13 @@
+ 	public $config;
+ 
+ 	/**
++	 * CI_URI class object
++	 *
++	 * @var	object
++	 */
++	public $uri;
++
++	/**
+ 	 * List of routes
+ 	 *
+ 	 * @var	array
+--- a/system/libraries/Image_lib.php
++++ b/system/libraries/Image_lib.php
+@@ -85,6 +85,14 @@
+ 	 */
+ 	public $new_image		= '';
+ 
++
++	/**
++	 * Path to destination image
++	 *
++	 * @var string
++	 */
++	public $dest_image		= '';
++
+ 	/**
+ 	 * Image width
+ 	 *

--- a/patches/Kenjis_CiPhpunitTest/v3.0.4/support_php-8.2.patch
+++ b/patches/Kenjis_CiPhpunitTest/v3.0.4/support_php-8.2.patch
@@ -1,0 +1,10 @@
+--- a/application/tests/_ci_phpunit_test/CIPHPUnitTestCase.php
++++ b/application/tests/_ci_phpunit_test/CIPHPUnitTestCase.php
+@@ -21,6 +21,7 @@
+  * @property CIPHPUnitTestDouble     $double
+  * @property CIPHPUnitTestReflection $reflection
+  */
++#[AllowDynamicProperties]
+ class CIPHPUnitTestCase extends TestCase
+ {
+ 	protected $_error_reporting = -1;

--- a/utils/composer.json
+++ b/utils/composer.json
@@ -1,0 +1,7 @@
+{
+    "require-dev": {
+        "friendsofphp/php-cs-fixer": "3.3.*",
+        "ise/php-codingstandards-codeigniter": "^1.0",
+        "squizlabs/php_codesniffer": "3.*"
+    }
+}

--- a/utils/fix_code_style.sh
+++ b/utils/fix_code_style.sh
@@ -25,6 +25,8 @@
 #
 #
 
+VENDOR_DIR="utils/vendor"
+
 if [[ "$1" == "git-co" ]]; then
   DO_GIT_COMMIT=1
   DO_GIT_DIFF=0
@@ -57,7 +59,7 @@ fi
 ############### Check for strict STRICT_COMPARISON operator #########
 
 if [[ "$STRICT_COMPARISON" == "1" ]]; then
-    vendor/bin/php-cs-fixer fix -v --show-progress=dots --allow-risky=yes --dry-run --diff --config "$CS_FIXER_CONF_DIR/php-cs-fixer-5-strict_comparison.php" > "$DIFF_OUTPUT_DIR/code_style_check-strict_comparison.diff"
+    ${VENDOR_DIR}/bin/php-cs-fixer fix -v --show-progress=dots --allow-risky=yes --dry-run --diff --config "$CS_FIXER_CONF_DIR/php-cs-fixer-5-strict_comparison.php" > "$DIFF_OUTPUT_DIR/code_style_check-strict_comparison.diff"
     EXIT_CODE=$?
     if [ $EXIT_CODE -eq 8 ] || [ $EXIT_CODE -eq 4 ]; then
         # 4 - Some files have invalid syntax (only in dry-run mode).
@@ -133,7 +135,7 @@ fi
 
 
 # Configure phpcs (add CodeIgniter standard to phpcs)
-vendor/bin/phpcs --config-set installed_paths vendor/ise/php-codingstandards-codeigniter/CodeIgniter
+${VENDOR_DIR}/bin/phpcs --config-set installed_paths ${VENDOR_DIR}/ise/php-codingstandards-codeigniter/CodeIgniter
 
 ############ Various change to harmonize code  #########
 
@@ -156,9 +158,9 @@ fi
 # https://codeigniter.com/userguide3/general/security.html?highlight=index%20html#hide-your-files
 # CodeIgniter will have an index.html file in all of its directories in an attempt
 # to hide some of this data, but have it in mind that this is not enough to prevent a serious attacker.
-#find application/ -type d -exec cp -a vendor/codeigniter/framework/application/index.html '{}' \;
-find application/ -type d '!' -exec test -e "{}/index.html" ';' -exec cp -a vendor/codeigniter/framework/application/index.html '{}' \; &&
-find media/ -type d '!' -exec test -e "{}/index.html" ';' -exec cp -a vendor/codeigniter/framework/application/index.html '{}' \; &&
+#find application/ -type d -exec cp -a ${VENDOR_DIR}/codeigniter/framework/application/index.html '{}' \;
+find application/ -type d '!' -exec test -e "{}/index.html" ';' -exec cp -a ${VENDOR_DIR}/codeigniter/framework/application/index.html '{}' \; &&
+find media/ -type d '!' -exec test -e "{}/index.html" ';' -exec cp -a ${VENDOR_DIR}/codeigniter/framework/application/index.html '{}' \; &&
 if [ $DO_GIT_COMMIT -eq 1 ]; then
     git add "application/**index.html" &&
     git add "media/**index.html" &&
@@ -187,7 +189,7 @@ unset OLD_CI_HEADER
 if [ $DO_GIT_DIFF -eq 0 ]; then
 
     # Correct spaces, end of line, tabs, indentation...
-    vendor/bin/php-cs-fixer fix -v --show-progress=dots --config "$CS_FIXER_CONF_DIR/php-cs-fixer-0-spaces.php" &&
+    ${VENDOR_DIR}/bin/php-cs-fixer fix -v --show-progress=dots --config "$CS_FIXER_CONF_DIR/php-cs-fixer-0-spaces.php" &&
     if [ $DO_GIT_COMMIT -eq 1 ]; then
         git add application &&
         git commit -m "[AUTO: PHP-CS-Fixer] spaces...
@@ -207,23 +209,23 @@ no_spaces_around_offset"
     fi
 
      # linebreak_after_opening_tag
-    vendor/bin/php-cs-fixer fix -v --show-progress=dots --config "$CS_FIXER_CONF_DIR/php-cs-fixer-9-linebreak_after_opening_tag.php" &&
+    ${VENDOR_DIR}/bin/php-cs-fixer fix -v --show-progress=dots --config "$CS_FIXER_CONF_DIR/php-cs-fixer-9-linebreak_after_opening_tag.php" &&
      # no_closing_tag
-    vendor/bin/php-cs-fixer fix -v --show-progress=dots --config "$CS_FIXER_CONF_DIR/php-cs-fixer-8-no_closing_tag.php" &&
+    ${VENDOR_DIR}/bin/php-cs-fixer fix -v --show-progress=dots --config "$CS_FIXER_CONF_DIR/php-cs-fixer-8-no_closing_tag.php" &&
     if [ $DO_GIT_COMMIT -eq 1 ]; then
         git add application &&
         git commit -m "[AUTO: PHP-CS-Fixer] no_closing_tag, linebreak_after_opening_tag"
     fi
 
     # single_quote
-    vendor/bin/php-cs-fixer fix -v --show-progress=dots --config "$CS_FIXER_CONF_DIR/php-cs-fixer-1-single_quote.php" &&
+    ${VENDOR_DIR}/bin/php-cs-fixer fix -v --show-progress=dots --config "$CS_FIXER_CONF_DIR/php-cs-fixer-1-single_quote.php" &&
     if [ $DO_GIT_COMMIT -eq 1 ]; then
         git add application &&
         git commit -m "[AUTO: PHP-CS-Fixer] single_quote"
     fi
 
     # method_argument_space
-    vendor/bin/php-cs-fixer fix -v --show-progress=dots --config "$CS_FIXER_CONF_DIR/php-cs-fixer-6-method_argument_space.php" &&
+    ${VENDOR_DIR}/bin/php-cs-fixer fix -v --show-progress=dots --config "$CS_FIXER_CONF_DIR/php-cs-fixer-6-method_argument_space.php" &&
     if [ $DO_GIT_COMMIT -eq 1 ]; then
         git add application &&
         git commit -m "[AUTO: PHP-CS-Fixer] method_argument_space
@@ -232,14 +234,14 @@ no_spaces_around_offset"
     fi
 
     # explicit_string_variable
-    vendor/bin/php-cs-fixer fix -v --show-progress=dots --config "$CS_FIXER_CONF_DIR/php-cs-fixer-7-explicit_string_variable.php" &&
+    ${VENDOR_DIR}/bin/php-cs-fixer fix -v --show-progress=dots --config "$CS_FIXER_CONF_DIR/php-cs-fixer-7-explicit_string_variable.php" &&
     if [ $DO_GIT_COMMIT -eq 1 ]; then
         git add application &&
         git commit -m "[AUTO: PHP-CS-Fixer] explicit_string_variable"
     fi
 
     # operator spacing (except some config files)
-    vendor/bin/php-cs-fixer fix -v --show-progress=dots --config "$CS_FIXER_CONF_DIR/php-cs-fixer-11-operator.php" &&
+    ${VENDOR_DIR}/bin/php-cs-fixer fix -v --show-progress=dots --config "$CS_FIXER_CONF_DIR/php-cs-fixer-11-operator.php" &&
     if [ $DO_GIT_COMMIT -eq 1 ]; then
         git add application &&
         git commit -m "[AUTO: PHP-CS-Fixer] operator & parenthesis spacing
@@ -258,7 +260,7 @@ no_spaces_around_offset"
     fi
 
     # constant_case  TRUE, FALSE
-    vendor/bin/php-cs-fixer fix -v --show-progress=dots --config "$CS_FIXER_CONF_DIR/php-cs-fixer-3-constant_case.php" &&
+    ${VENDOR_DIR}/bin/php-cs-fixer fix -v --show-progress=dots --config "$CS_FIXER_CONF_DIR/php-cs-fixer-3-constant_case.php" &&
     if [ $DO_GIT_COMMIT -eq 1 ]; then
         git add application &&
         git commit -m "[AUTO: PHP-CS-Fixer] constant_case
@@ -267,19 +269,19 @@ no_spaces_around_offset"
     fi
 
     # single_line_comment_style
-    vendor/bin/php-cs-fixer fix -v --show-progress=dots --config "$CS_FIXER_CONF_DIR/php-cs-fixer-10-single_line_comment_style.php" &&
+    ${VENDOR_DIR}/bin/php-cs-fixer fix -v --show-progress=dots --config "$CS_FIXER_CONF_DIR/php-cs-fixer-10-single_line_comment_style.php" &&
     if [ $DO_GIT_COMMIT -eq 1 ]; then
         git add application &&
         git commit -m "[AUTO: PHP-CS-Fixer] single_line_comment_style"
     fi
 
     # no_alternative_syntax (EXCEPT views)
-    vendor/bin/php-cs-fixer fix -v --show-progress=dots --config "$CS_FIXER_CONF_DIR/php-cs-fixer-12-no_alternative_syntax.php" &&
+    ${VENDOR_DIR}/bin/php-cs-fixer fix -v --show-progress=dots --config "$CS_FIXER_CONF_DIR/php-cs-fixer-12-no_alternative_syntax.php" &&
     # braces & control_structure_continuation_position & no_alternative_syntax
-    vendor/bin/php-cs-fixer fix -v --show-progress=dots --config "$CS_FIXER_CONF_DIR/php-cs-fixer-4-braces.php" &&
+    ${VENDOR_DIR}/bin/php-cs-fixer fix -v --show-progress=dots --config "$CS_FIXER_CONF_DIR/php-cs-fixer-4-braces.php" &&
     # Run phpcs immediately with sniffs=Generic.Classes.OpeningBraceSameLine to fix
     # php-cs-fixer not inline with what we want
-    vendor/bin/phpcbf -p --standard="$CS_RULESSET_DIR/ruleset.xml" --sniffs=Generic.Classes.OpeningBraceSameLine
+    ${VENDOR_DIR}/bin/phpcbf -p --standard="$CS_RULESSET_DIR/ruleset.xml" --sniffs=Generic.Classes.OpeningBraceSameLine
     if [ $DO_GIT_COMMIT -eq 1 ]; then
         git add application &&
         git commit -m "[AUTO: PHP-CS-Fixer] braces, no_alt_syntax and related...
@@ -297,8 +299,8 @@ fi
 
 
 # Rerun php-cs-fixer with all fixes + the fix on classes opening braces
-vendor/bin/php-cs-fixer fix -v --show-progress=dots &&
-vendor/bin/phpcbf -p --standard="$CS_RULESSET_DIR/ruleset.xml" --sniffs=Generic.Classes.OpeningBraceSameLine
+${VENDOR_DIR}/bin/php-cs-fixer fix -v --show-progress=dots &&
+${VENDOR_DIR}/bin/phpcbf -p --standard="$CS_RULESSET_DIR/ruleset.xml" --sniffs=Generic.Classes.OpeningBraceSameLine
 if [ $DO_GIT_COMMIT -eq 1 ]; then
     git add application &&
     git commit -m "[AUTO: PHP-CS-Fixer] EMPTY?"
@@ -306,8 +308,8 @@ fi
 
 
 # Process also the scripts directory
-vendor/bin/php-cs-fixer fix -v --show-progress=dots scripts &&
-vendor/bin/phpcbf -p --standard="$CS_RULESSET_DIR/ruleset.xml" --sniffs=Generic.Classes.OpeningBraceSameLine scripts
+${VENDOR_DIR}/bin/php-cs-fixer fix -v --show-progress=dots scripts &&
+${VENDOR_DIR}/bin/phpcbf -p --standard="$CS_RULESSET_DIR/ruleset.xml" --sniffs=Generic.Classes.OpeningBraceSameLine scripts
 if [ $DO_GIT_COMMIT -eq 1 ]; then
     git add scripts &&
     git commit -m "[AUTO: PHP-CS-Fixer] scripts directory"
@@ -316,9 +318,9 @@ fi
 
 ############# PHP_CodeSniffer #############
 # First we check the errors
-vendor/bin/phpcs -p -s --standard="$CS_RULESSET_DIR/ruleset.xml" 2>&1 | tee "$TMPDIR/phpcs.log" &&
+${VENDOR_DIR}/bin/phpcs -p -s --standard="$CS_RULESSET_DIR/ruleset.xml" 2>&1 | tee "$TMPDIR/phpcs.log" &&
 # Then we fix them
-vendor/bin/phpcbf -p --standard="$CS_RULESSET_DIR/ruleset.xml" 2>&1 | tee "$TMPDIR/phpcbf.log"
+${VENDOR_DIR}/bin/phpcbf -p --standard="$CS_RULESSET_DIR/ruleset.xml" 2>&1 | tee "$TMPDIR/phpcbf.log"
 if [ $DO_GIT_COMMIT -eq 1 ]; then
     git add application &&
     git commit -m "[AUTO: CodeSniffer] Fixes to fit to to CI3 coding style"
@@ -356,7 +358,7 @@ fi
 
 # Check the views for any errors
 # Disabled for now
-#vendor/bin/phpcs -p -s --standard="$CS_RULESSET_DIR/ruleset-views.xml" 2>&1 | tee "$TMPDIR/phpcs-views.log"
+#${VENDOR_DIR}/bin/phpcs -p -s --standard="$CS_RULESSET_DIR/ruleset-views.xml" 2>&1 | tee "$TMPDIR/phpcs-views.log"
 #grep "| ERROR" phpcs-views.log | cut -d '|' -f 3- | sort | uniq -c
 #grep "| WARNING" phpcs-views.log | cut -d '|' -f 3- | sort | uniq -c
 #


### PR DESCRIPTION
This will:
- ensure code style fixes/checks are always made with the same version for everyone and don't depend on the dependencies installed for kalkun
- run tests from php 5.6 to the latest php version (list of released versions is dynamically fetched from php.net). BTW adding support for phpunit ranges from phpunit4 to phpunit10.
- fix some code deprecations reported by php 8.1 & 8.2
- add patches to add support for php 8.2 to dependencies (ci3 & kenjis/ci-phpunit-test)