### PR TITLE
PHP8.1: b8 spam filter: add connection arg to pg_escape_string() call

### DIFF
--- a/application/libraries/b8/storage/pgsql.php
+++ b/application/libraries/b8/storage/pgsql.php
@@ -55,7 +55,7 @@ class pgsql extends storage_base
 
         $escaped = [];
         foreach ($tokens as $token) {
-            $escaped[] = pg_escape_string($token);
+            $escaped[] = pg_escape_string($this->pgsql, $token);
         }
         $result = pg_query($this->pgsql, 'SELECT token, count_ham, count_spam'
                                       . ' FROM ' . $this->table


### PR DESCRIPTION
PHP8.1: b8 spam filter: add connection arg to pg_escape_string() call
Required since PHP 8.1