### PR TITLE
remove argument of phonebook_ldap() hook

### DIFF
--- a/application/plugins/phonebook_ldap/phonebook_ldap.php
+++ b/application/plugins/phonebook_ldap/phonebook_ldap.php
@@ -28,7 +28,7 @@ class Phonebook_ldap_plugin extends CI3_plugin_system {
 	 * with modification
 	 *
 	 */
-	function phonebook_ldap($number)
+	function phonebook_ldap()
 	{
 		if ( ! extension_loaded('ldap'))
 		{


### PR DESCRIPTION
It is not used anywhere, and since we call the hook without argument it would return an php error anyway