### PR TITLE
fix deprecation error that led to hidden HTTP 500 error

### DIFF
--- a/application/views/js_init/message/js_conversation.php
+++ b/application/views/js_init/message/js_conversation.php
@@ -247,7 +247,7 @@
 					break;
 				default:
 					var type = 'reply';
-					var phone = '<?php echo rawurldecode($this->uri->segment(5));?>';
+					var phone = '<?php echo rawurldecode(strval($this->uri->segment(5)));?>';
 					if (phone == null || phone == '')
 						var phone = $(this).parents('div:eq(1)').children().children('input.item_number').val();
 					compose_message('reply', false, '#message', phone);


### PR DESCRIPTION
Browser reported HTTP error 500 when doing a search with the search bar.

Kalkun log reported:
Severity: error --> Exception: rawurldecode(): Passing null to parameter #1 () of type string is deprecated
application/views/js_init/message/js_conversation.php 250