### PR TITLE
Update actions/* in github workflows

### DIFF
--- a/.github/workflows/codeigniter.yml
+++ b/.github/workflows/codeigniter.yml
@@ -167,7 +167,7 @@ jobs:
           utils/fix_code_style.sh git-diff
       - name: Archive artifacts
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: Code style issues to fix
           path: 'code_style_check*'
@@ -211,7 +211,7 @@ jobs:
           ./utils/check_translation.php all > pipe
       - name: Archive artifacts
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: Translation check output
           path: 'translation_check_output.*'

--- a/.github/workflows/codeigniter.yml
+++ b/.github/workflows/codeigniter.yml
@@ -58,7 +58,7 @@ jobs:
     runs-on: ${{ matrix.operating-system }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Setup PHP, with composer and extensions
         uses: shivammathur/setup-php@v2 #https://github.com/shivammathur/setup-php
         with:
@@ -69,7 +69,7 @@ jobs:
         id: composer-cache
         run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
       - name: Cache composer dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
           # Use composer.json for key, if composer.lock is not committed.
@@ -123,7 +123,7 @@ jobs:
     runs-on: ${{ matrix.operating-system }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Setup PHP, with composer and extensions
         uses: shivammathur/setup-php@v2 #https://github.com/shivammathur/setup-php
         with:
@@ -134,7 +134,7 @@ jobs:
         id: composer-cache
         run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
       - name: Cache composer dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
           # Use composer.json for key, if composer.lock is not committed.
@@ -181,7 +181,7 @@ jobs:
     continue-on-error: true
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Setup PHP, with composer and extensions
         uses: shivammathur/setup-php@v2 #https://github.com/shivammathur/setup-php
         with:
@@ -192,7 +192,7 @@ jobs:
         id: composer-cache
         run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
       - name: Cache composer dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
           # Use composer.json for key, if composer.lock is not committed.

--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -17,7 +17,7 @@ jobs:
       DPUT_CF: /home/runner/dput.cf
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Install required packages
         run: |
           sudo apt-get update
@@ -187,7 +187,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Composer (php-actions)
         uses: php-actions/composer@v6
         with:

--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -129,14 +129,14 @@ jobs:
           echo "my_home=$HOME" >> $GITHUB_ENV
       - name: Archive artifacts
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: Debian packages (source & binary)
           path: ~/Kalkun_${{ github.ref_name }}_debianBundle/*
           if-no-files-found: ignore
       - name: Archive artifacts
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: Debian packages (source & binary) tarball
           path: ~/Kalkun_${{ github.ref_name }}_debianBundle.tar
@@ -209,7 +209,7 @@ jobs:
           ls dist
       - name: Archive artifacts (all prebuilt packages)
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: Prebuilt packages (all)
           path: 'dist/'
@@ -226,7 +226,7 @@ jobs:
     steps:
       - name: Download artifact of 'prebuilt packages'
         if: always()
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: Prebuilt packages (all)
           path: 'dist/'
@@ -235,7 +235,7 @@ jobs:
         working-directory: 'dist'
       - name: Archive artifacts for ${{ matrix.version }}
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: Prebuilt package for PHP ${{ matrix.version }}
           path: 'dist/*forPHP${{ matrix.version }}.[tz]*'
@@ -248,13 +248,13 @@ jobs:
     steps:
       - name: Download artifact of 'prebuilt packages'
         if: startsWith(github.ref, 'refs/tags/')
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: Prebuilt packages (all)
           path: 'dist/'
       - name: Download artifact of 'Debian packages'
         if: startsWith(github.ref, 'refs/tags/')
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: Debian packages (source & binary) tarball
           path: 'dist/'
@@ -284,11 +284,11 @@ jobs:
     name: Delete temporary artifact
     runs-on: ubuntu-latest
     steps:
-      - uses: geekyeggo/delete-artifact@v2
+      - uses: geekyeggo/delete-artifact@v6
         with:
           name: Prebuilt packages (all)
           failOnError: false
-      - uses: geekyeggo/delete-artifact@v2
+      - uses: geekyeggo/delete-artifact@v6
         with:
           name: Debian packages (source & binary) tarball
           failOnError: false


### PR DESCRIPTION
Permits to upgrade to node24 since node20 is deprecated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow dependencies to latest versions for improved compatibility and security.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kalkun-sms/Kalkun/pull/554)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->